### PR TITLE
[운영서비스] 출석 점수 조회 QA 반영

### DIFF
--- a/app/src/main/java/org/sopt/official/data/service/attendance/AttendanceService.kt
+++ b/app/src/main/java/org/sopt/official/data/service/attendance/AttendanceService.kt
@@ -6,9 +6,9 @@ import org.sopt.official.data.model.attendance.SoptEventResponse
 import retrofit2.http.GET
 
 interface AttendanceService {
-    @GET("/api/v1/app/lecture")
+    @GET("/api/v1/app/lectures")
     suspend fun getSoptEvent(): BaseAttendanceResponse<SoptEventResponse>
 
-    @GET("/api/v1/app/total")
+    @GET("/api/v1/app/members/attendances")
     suspend fun getAttendanceHistory(): BaseAttendanceResponse<AttendanceHistoryResponse>
 }

--- a/app/src/main/java/org/sopt/official/di/NetModule.kt
+++ b/app/src/main/java/org/sopt/official/di/NetModule.kt
@@ -65,7 +65,6 @@ object NetModule {
         .baseUrl(if (BuildConfig.DEBUG) BuildConfig.devApi else BuildConfig.newApi)
         .build()
 
-    // TODO by Nunu, IceMan devOperationApi -> OperationApi로 바꿔주세요!
     @OperationRetrofit
     @Provides
     @Singleton
@@ -75,6 +74,6 @@ object NetModule {
     ): Retrofit = Retrofit.Builder()
         .client(client)
         .addConverterFactory(converter)
-        .baseUrl(if (BuildConfig.DEBUG) BuildConfig.devOperationApi else BuildConfig.devOperationApi)
+        .baseUrl(if (BuildConfig.DEBUG) BuildConfig.devOperationApi else BuildConfig.operationApi)
         .build()
 }

--- a/app/src/main/java/org/sopt/official/feature/attendance/AttendanceActivity.kt
+++ b/app/src/main/java/org/sopt/official/feature/attendance/AttendanceActivity.kt
@@ -118,6 +118,10 @@ class AttendanceActivity : AppCompatActivity() {
                             updateSoptEventComponent(it.data)
                         }
 
+                        is AttendanceState.Failure -> {
+                            Toast.makeText(this@AttendanceActivity, "문제가 발생했습니다", Toast.LENGTH_SHORT).show()
+                        }
+
                         else -> {}
                     }
                 }
@@ -133,7 +137,11 @@ class AttendanceActivity : AppCompatActivity() {
                         is AttendanceState.Success -> {
                             updateAttendanceUserInfo(attendanceHistory.data.userInfo)
                             updateAttendanceSummary(attendanceHistory.data.attendanceSummary)
-                            updateAttendanceLog(attendanceHistory.data.attendanceLog.filterNot { it.attribute == EventAttribute.ETC && it.attendanceState != AttendanceStatus.PARTICIPATE.statusKorean })
+                            updateAttendanceLog(attendanceHistory.data.attendanceLog)
+                        }
+
+                        is AttendanceState.Failure -> {
+                            Toast.makeText(this@AttendanceActivity, "문제가 발생했습니다", Toast.LENGTH_SHORT).show()
                         }
 
                         else -> {}
@@ -231,8 +239,11 @@ class AttendanceActivity : AppCompatActivity() {
         attendanceAdapter.updateSummary(summary)
     }
 
-    private fun updateAttendanceLog(log: List<AttendanceLog>) {
-        attendanceAdapter.submitList(log)
+    private fun updateAttendanceLog(log: List<AttendanceLog?>) {
+        val list = log.toMutableList().apply {
+            repeat(3) { add(0, null) }
+        }
+        attendanceAdapter.submitList(list)
         binding.recyclerViewAttendanceHistory.scrollToPosition(0)
     }
 }

--- a/app/src/main/java/org/sopt/official/feature/attendance/AttendanceActivity.kt
+++ b/app/src/main/java/org/sopt/official/feature/attendance/AttendanceActivity.kt
@@ -8,10 +8,11 @@ import android.text.Spannable
 import android.text.Spanned
 import android.text.style.StyleSpan
 import android.view.*
+import android.view.animation.AnimationUtils
 import android.widget.TextView
+import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -31,22 +32,6 @@ class AttendanceActivity : AppCompatActivity() {
     private lateinit var binding: ActivityAttendanceBinding
     private val attendanceViewModel by viewModels<AttendanceViewModel>()
     private lateinit var attendanceAdapter: AttendanceAdapter
-    private val menuProvider = (object : MenuProvider {
-        override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
-            menuInflater.inflate(R.menu.menu_attendance_overview, menu)
-        }
-
-        override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
-            return when (menuItem.itemId) {
-                R.id.menu_refresh -> {
-                    attendanceViewModel.fetchSoptEvent()
-                    attendanceViewModel.fetchAttendanceHistory()
-                    true
-                }
-                else -> false
-            }
-        }
-    })
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -54,6 +39,7 @@ class AttendanceActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         initView()
+        initUiInteraction()
         fetchData()
         observeData()
     }
@@ -61,6 +47,16 @@ class AttendanceActivity : AppCompatActivity() {
     private fun initView() {
         initToolbar()
         initRecyclerView()
+    }
+
+    private fun initUiInteraction() {
+        binding.icRefresh.setOnClickListener {
+            it.startAnimation(AnimationUtils.loadAnimation(this, R.anim.anim_rotation))
+            attendanceViewModel.run {
+                fetchSoptEvent()
+                fetchAttendanceHistory()
+            }
+        }
     }
 
     private fun fetchData() {
@@ -80,7 +76,6 @@ class AttendanceActivity : AppCompatActivity() {
             setSupportActionBar(this)
             setNavigationOnClickListener { this@AttendanceActivity.finish() }
         }
-        addMenuProvider(menuProvider, this)
         supportActionBar?.setDisplayShowTitleEnabled(false)
     }
 

--- a/app/src/main/java/org/sopt/official/feature/attendance/adapter/AttendanceAdapter.kt
+++ b/app/src/main/java/org/sopt/official/feature/attendance/adapter/AttendanceAdapter.kt
@@ -23,7 +23,7 @@ class AttendanceAdapter : ListAdapter<AttendanceLog, RecyclerView.ViewHolder>(di
     }
 
     override fun getItemCount(): Int {
-        return currentList.size + 3
+        return currentList.size
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
@@ -31,7 +31,7 @@ class AttendanceAdapter : ListAdapter<AttendanceLog, RecyclerView.ViewHolder>(di
             is UserInfoViewHolder -> userInfo?.let { holder.onBind(it) }
             is SummaryViewHolder -> summary?.let { holder.onBind(it) }
             is LogHeaderViewHolder -> {}
-            is LogViewHolder -> holder.onBind(currentList[position - 3])
+            is LogViewHolder -> holder.onBind(currentList[position])
             else -> throw IllegalArgumentException("Illegal holder argument: ${holder::class.java.simpleName}")
         }
     }

--- a/app/src/main/java/org/sopt/official/feature/attendance/adapter/SummaryViewHolder.kt
+++ b/app/src/main/java/org/sopt/official/feature/attendance/adapter/SummaryViewHolder.kt
@@ -3,7 +3,6 @@ package org.sopt.official.feature.attendance.adapter
 import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import org.sopt.official.databinding.ItemAttendanceHistorySummaryBinding
 import org.sopt.official.domain.entity.attendance.AttendanceSummary
@@ -20,8 +19,6 @@ class SummaryViewHolder(private val binding: ItemAttendanceHistorySummaryBinding
             textAttendanceCountLate.text = "${summary.late}회"
             textAttendanceCountAbnormal.text = "${summary.abnormal}회"
             textAttendanceCountParticipate.text = "${summary.participate}회"
-
-            layoutAttendanceParticipate.isVisible = (summary.participate != 0)
         }
     }
 

--- a/app/src/main/res/anim/anim_rotation.xml
+++ b/app/src/main/res/anim/anim_rotation.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="1000">
+    <rotate
+        android:fromDegrees="360"
+        android:toDegrees="0"
+        android:pivotX="50%"
+        android:pivotY="50%" />
+</set>

--- a/app/src/main/res/layout/activity_attendance.xml
+++ b/app/src/main/res/layout/activity_attendance.xml
@@ -28,6 +28,15 @@
                     android:text="@string/attendance"
                     android:textColor="?colorOnBackground"
                     android:textSize="16sp" />
+
+                <ImageView
+                    android:id="@+id/ic_refresh"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="end"
+                    android:layout_marginEnd="20dp"
+                    android:src="@drawable/ic_refresh" />
+
             </androidx.appcompat.widget.Toolbar>
         </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/layout/item_attendance_history_log.xml
+++ b/app/src/main/res/layout/item_attendance_history_log.xml
@@ -28,7 +28,7 @@
         style="@style/TextAppearance.SOPT"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="8dp"
+        android:layout_marginHorizontal="10dp"
         android:ellipsize="end"
         android:maxLines="1"
         android:textColor="?colorOnSurface"


### PR DESCRIPTION
## What is this issue?
- [x] #138 

[운영서비스] 출석 점수 조회 QA 시 나왔던 이슈들을 해결했습니다.
- '참여' 태그의 행사 참여가 0회일 때에도 참여 태그 행사의 참석 횟수를 보여줍니다.
- Retrofit baseUrl을 Build Type에 따라 개발 서버, 실 서버 다르게 연결합니다.
- 디자인 측에서 제안한대로 TextView의 양쪽 마진값을 조정했습니다.
- 서버 측에서 수정한 EndPoint를 반영했습니다.
- 새로고침 아이콘 클릭 시 아이콘을 회전시킵니다.
- 새로고침 시 RecyclerView의 다른 position이 깜빡이는 오류를 발견해 임시조치 해두었습니다. 추후 리프레시 기간을 활용해 정식으로 조치하도록 하겠습니다.