### PR TITLE
[feature/junit5-configuration] 테스트 라이브러리 JUnit5로 교체

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ import java.util.*
 
 plugins {
     id("org.sopt.official.application")
+    id("org.sopt.official.junit5")
     alias(libs.plugins.google.services)
     alias(libs.plugins.crashlytics)
     alias(libs.plugins.ktlint)
@@ -98,7 +99,6 @@ dependencies {
     ksp(libs.compose.destination.ksp)
 
     androidTestImplementation(platform(libs.compose.bom))
-    testImplementation(libs.junit)
     androidTestImplementation(libs.bundles.compose.test)
     androidTestImplementation(libs.bundles.android.test)
     debugImplementation(libs.bundles.compose.android.test)

--- a/app/src/test/java/org/sopt/official/JsonObjectTest.kt
+++ b/app/src/test/java/org/sopt/official/JsonObjectTest.kt
@@ -4,11 +4,13 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import org.junit.Test
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
 class JsonObjectTest {
     @Test
-    fun `json에 message라는 프로퍼티가 kotlinx serialization의 JsonObject로 객체화 시켰을 때에도 잘 가져와진다`() {
+    @DisplayName("json에 message라는 프로퍼티가 kotlinx serialization의 JsonObject로 객체화 시켰을 때에도 잘 가져와진다")
+    fun parsingJsonTest() {
         val json = """
             {
                 "message": "1차 출석이 이미 종료되었습니다."

--- a/app/src/test/java/org/sopt/official/JsonObjectTest.kt
+++ b/app/src/test/java/org/sopt/official/JsonObjectTest.kt
@@ -1,5 +1,6 @@
 package org.sopt.official
 
+import com.google.common.truth.Truth.assertThat
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
@@ -11,13 +12,17 @@ class JsonObjectTest {
     @Test
     @DisplayName("json에 message라는 프로퍼티가 kotlinx serialization의 JsonObject로 객체화 시켰을 때에도 잘 가져와진다")
     fun parsingJsonTest() {
+        // given
         val json = """
             {
                 "message": "1차 출석이 이미 종료되었습니다."
             }
         """.trimIndent()
 
+        // when
         val message = Json.parseToJsonElement(json).jsonObject["message"]?.jsonPrimitive?.contentOrNull
-        assert(message == "1차 출석이 이미 종료되었습니다.")
+        
+        // then
+        assertThat(message).isEqualTo("1차 출석이 이미 종료되었습니다.")
     }
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -36,5 +36,9 @@ gradlePlugin {
             id = "org.sopt.official.serialization"
             implementationClass = "org.sopt.official.plugin.KotlinSerializationPlugin"
         }
+        create("junit5") {
+            id = "org.sopt.official.junit5"
+            implementationClass = "org.sopt.official.plugin.JUnit5Plugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/org/sopt/official/plugin/JUnit5Plugin.kt
+++ b/build-logic/convention/src/main/kotlin/org/sopt/official/plugin/JUnit5Plugin.kt
@@ -15,6 +15,7 @@ class JUnit5Plugin : Plugin<Project> {
 
         dependencies {
             "testImplementation"(libs.findBundle("junit5.test").get())
+            "testImplementation"(libs.findLibrary("truth").get())
             "androidTestImplementation"(libs.findLibrary("junit5").get())
         }
     }

--- a/build-logic/convention/src/main/kotlin/org/sopt/official/plugin/JUnit5Plugin.kt
+++ b/build-logic/convention/src/main/kotlin/org/sopt/official/plugin/JUnit5Plugin.kt
@@ -1,0 +1,21 @@
+package org.sopt.official.plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+
+class JUnit5Plugin : Plugin<Project> {
+    override fun apply(target: Project): Unit = with(target) {
+        with(plugins) {
+            apply("de.mannodermaus.android-junit5")
+        }
+        val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+        dependencies {
+            "testImplementation"(libs.findBundle("junit5.test").get())
+            "androidTestImplementation"(libs.findLibrary("junit5").get())
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
     alias(libs.plugins.secret) apply false
     alias(libs.plugins.kotlinx.serialization) apply false
     alias(libs.plugins.sentry) apply false
+    alias(libs.plugins.junit5) apply false
 }
 
 tasks.register("clean", Delete::class) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ androidx-test-junit = "1.1.5"
 androidx-test-espresso = "3.5.1"
 junit5-plugin = "1.9.3.0"
 junit5-jupiter = "5.9.3"
+truth = "1.1.3"
 
 gradleplugin = "7.4.2"
 kspplugin = "1.8.10-1.0.9"
@@ -109,6 +110,7 @@ androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", vers
 junit5 = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5-jupiter" }
 junit5-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5-jupiter" }
 junit5-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5-jupiter" }
+truth = { module = "com.google.truth:truth", version.ref = "truth" }
 
 flipper = { module = "com.facebook.flipper:flipper", version.ref = "flipper" }
 flipper-noop = { module = "com.facebook.flipper:flipper-noop", version.ref = "flipper" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,8 @@ secret-gradle-plugin = "2.0.1"
 junit = "4.13.2"
 androidx-test-junit = "1.1.5"
 androidx-test-espresso = "3.5.1"
+junit5-plugin = "1.9.3.0"
+junit5-jupiter = "5.9.3"
 
 gradleplugin = "7.4.2"
 kspplugin = "1.8.10-1.0.9"
@@ -104,6 +106,9 @@ coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 junit = { module = "junit:junit", version.ref = "junit" }
 androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-junit" }
 androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-test-espresso" }
+junit5 = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5-jupiter" }
+junit5-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5-jupiter" }
+junit5-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5-jupiter" }
 
 flipper = { module = "com.facebook.flipper:flipper", version.ref = "flipper" }
 flipper-noop = { module = "com.facebook.flipper:flipper-noop", version.ref = "flipper" }
@@ -168,6 +173,7 @@ flipper = ["flipper", "soloader"]
 firebase = ["firebase-analytics", "firebase-crashlytics", "firebase-messaging"]
 accompanist = ["accompanist-systemuicontroller"]
 mavericks = ["mavericks", "mavericks-compose", "mavericks-navigation", "mavericks-mockable"]
+junit5-test = ["junit5", "junit5-engine", "junit5-params"]
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "gradleplugin" }
@@ -182,3 +188,4 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "kspplugin" }
 secret = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secret-gradle-plugin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 sentry = { id = "io.sentry.android.gradle", version.ref = "sentry" }
+junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "junit5-plugin" }


### PR DESCRIPTION
## What is this issue?
- [x] 이번에 kotlinx serialization으로 JsonObject를 쌩파싱하는 케이스가 있었는데 검증을 하는 것에 서버에 의존성이 생겨서 그냥 테스트 코드로 검증을 해봤습니다.
- [x] 이런식으로 테스트에 다른 의존성이 있는 경우 테스트 코드를 통해 검증을 좀 더 쉽고 빠르게 할 수 있는데, 그 과정을 조금 더 용이하게 하기 위한 라이브러리 교체를 진행했습니다 (JUnit5으로 테스트 컨테이너 교체, truth로 조금 더 용이한 assertion 작성) 

## Reference
- [Test를 JUnit5로 작성하기](https://modelmaker.tistory.com/entry/%EC%95%88%EB%93%9C%EB%A1%9C%EC%9D%B4%EB%93%9C-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%BD%94%EB%93%9C-Truth-with-JUnit5)
