### PR TITLE
[feature/nunu/retry-make-shared-preference] SharedPreference 초기화 시 앱 강제 종료되는 이슈 의심 되는 부분 수정

### DIFF
--- a/app/src/main/java/org/sopt/official/data/persistence/SoptDataStore.kt
+++ b/app/src/main/java/org/sopt/official/data/persistence/SoptDataStore.kt
@@ -1,8 +1,6 @@
 package org.sopt.official.data.persistence
 
 import android.content.Context
-import android.content.SharedPreferences
-import android.os.Build
 import androidx.core.content.edit
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
@@ -54,7 +52,9 @@ class SoptDataStore @Inject constructor(
     }
 
     fun clear() {
-        store.edit().clear().commit()
+        store.edit(true) {
+            clear()
+        }
     }
 
     var accessToken: String

--- a/app/src/main/java/org/sopt/official/data/persistence/SoptDataStore.kt
+++ b/app/src/main/java/org/sopt/official/data/persistence/SoptDataStore.kt
@@ -1,12 +1,16 @@
 package org.sopt.official.data.persistence
 
 import android.content.Context
+import android.content.SharedPreferences
+import android.os.Build
 import androidx.core.content.edit
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.sopt.official.BuildConfig
 import org.sopt.official.domain.entity.auth.UserStatus
+import timber.log.Timber
+import java.security.KeyStore
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -14,9 +18,16 @@ import javax.inject.Singleton
 class SoptDataStore @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
-    private val store = if (BuildConfig.DEBUG) {
-        context.getSharedPreferences(DEBUG_FILE_NAME, Context.MODE_PRIVATE)
-    } else {
+    private val store = try {
+        createSharedPreference(!BuildConfig.DEBUG)
+    } catch (e: Exception) {
+        Timber.e(e)
+        deleteMasterKeyEntry()
+        deleteEncryptedPreference()
+        createSharedPreference(!BuildConfig.DEBUG)
+    }
+
+    private fun createSharedPreference(isEncrypted: Boolean) = if (isEncrypted) {
         EncryptedSharedPreferences.create(
             BuildConfig.persistenceStoreName,
             MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
@@ -24,6 +35,22 @@ class SoptDataStore @Inject constructor(
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         )
+    } else {
+        context.getSharedPreferences(DEBUG_FILE_NAME, Context.MODE_PRIVATE)
+    }
+
+    /**
+     * androidx.security.crypto.MasterKeys.ANDROID_KEYSTORE 참고
+     */
+    private fun deleteMasterKeyEntry() {
+        KeyStore.getInstance("AndroidKeyStore").apply {
+            load(null)
+            deleteEntry(KEY_ALIAS_AUTH)
+        }
+    }
+
+    private fun deleteEncryptedPreference() {
+        context.deleteSharedPreferences(BuildConfig.persistenceStoreName)
     }
 
     fun clear() {
@@ -52,5 +79,6 @@ class SoptDataStore @Inject constructor(
         private const val REFRESH_TOKEN = "refresh_token"
         private const val PLAYGROUND_TOKEN = "pg_token"
         private const val USER_STATUS = "user_status"
+        private const val KEY_ALIAS_AUTH = "alias.preferences.auth_token"
     }
 }


### PR DESCRIPTION
## What is this issue?
- [x] 기기 내의 MasterKey or EncryptedSharedPreference가 손상되면 앱 강제종료가 되는 현상이 있는데 GDE나 GDG 분들한테 물어봐서 의심되는 부분을 수정해봤습니다.
- [x] 그냥 마스터 키 엔트리/SharedPreference 삭제하고 다시 만드는 로직을 짜봤습니다.
