### PR TITLE
[Feature/kotlinx-datetime]: #204 java-time to kotlinx-datetime migration 

### DIFF
--- a/app/src/main/java/org/sopt/official/feature/main/MainViewModel.kt
+++ b/app/src/main/java/org/sopt/official/feature/main/MainViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Instant
 import org.sopt.official.R
 import org.sopt.official.base.BaseItemType
 import org.sopt.official.domain.entity.UserState
@@ -16,8 +17,9 @@ import org.sopt.official.domain.entity.main.MainViewResult
 import org.sopt.official.domain.entity.main.MainViewUserInfo
 import org.sopt.official.domain.repository.main.MainViewRepository
 import org.sopt.official.feature.web.WebUrlConstant
-import org.sopt.official.util.computeMothUntilNow
-import org.sopt.official.util.getCurrentInstant
+import org.sopt.official.util.calculateDurationOfGeneration
+import org.sopt.official.util.calculateGenerationStartDate
+import org.sopt.official.util.systemNow
 import org.sopt.official.util.toDefaultLocalDate
 import org.sopt.official.util.wrapper.NullableWrapper
 import org.sopt.official.util.wrapper.asNullableWrapper
@@ -37,8 +39,10 @@ class MainViewModel @Inject constructor(
         .map {
             val state = it.status
             val userName = it.name.getOrEmpty()
-            val currentDate = getCurrentInstant().toDefaultLocalDate()
-            val period = computeMothUntilNow(it.generationList.get()?.last()?.toInt() ?: 0, currentDate)
+            val generation = it.generationList.get()?.last()?.toInt() ?: 0
+            val startDate = calculateGenerationStartDate(generation)
+            val currentDate = Instant.systemNow().toDefaultLocalDate()
+            val period = calculateDurationOfGeneration(startDate, currentDate)
             when {
                 userName.isNotEmpty() -> Triple(R.string.main_title_member, userName, period.toString())
                 state == UserState.INACTIVE -> Triple(R.string.main_title_inactive_member, null, null)

--- a/app/src/main/java/org/sopt/official/feature/main/MainViewModel.kt
+++ b/app/src/main/java/org/sopt/official/feature/main/MainViewModel.kt
@@ -7,6 +7,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import org.sopt.official.R
 import org.sopt.official.base.BaseItemType
 import org.sopt.official.domain.entity.UserState
@@ -35,7 +38,8 @@ class MainViewModel @Inject constructor(
         .map {
             val state = it.status
             val userName = it.name.getOrEmpty()
-            val period = computeMothUntilNow(it.generationList.get()?.last()?.toInt() ?: 0)
+            val currentTime = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+            val period = computeMothUntilNow(it.generationList.get()?.last()?.toInt() ?: 0, currentTime)
             when {
                 userName.isNotEmpty() -> Triple(R.string.main_title_member, userName, period.toString())
                 state == UserState.INACTIVE -> Triple(R.string.main_title_inactive_member, null, null)

--- a/app/src/main/java/org/sopt/official/feature/main/MainViewModel.kt
+++ b/app/src/main/java/org/sopt/official/feature/main/MainViewModel.kt
@@ -7,9 +7,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import org.sopt.official.R
 import org.sopt.official.base.BaseItemType
 import org.sopt.official.domain.entity.UserState
@@ -20,6 +17,8 @@ import org.sopt.official.domain.entity.main.MainViewUserInfo
 import org.sopt.official.domain.repository.main.MainViewRepository
 import org.sopt.official.feature.web.WebUrlConstant
 import org.sopt.official.util.computeMothUntilNow
+import org.sopt.official.util.getCurrentInstant
+import org.sopt.official.util.toDefaultLocalDate
 import org.sopt.official.util.wrapper.NullableWrapper
 import org.sopt.official.util.wrapper.asNullableWrapper
 import org.sopt.official.util.wrapper.getOrEmpty
@@ -38,8 +37,8 @@ class MainViewModel @Inject constructor(
         .map {
             val state = it.status
             val userName = it.name.getOrEmpty()
-            val currentTime = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
-            val period = computeMothUntilNow(it.generationList.get()?.last()?.toInt() ?: 0, currentTime)
+            val currentDate = getCurrentInstant().toDefaultLocalDate()
+            val period = computeMothUntilNow(it.generationList.get()?.last()?.toInt() ?: 0, currentDate)
             when {
                 userName.isNotEmpty() -> Triple(R.string.main_title_member, userName, period.toString())
                 state == UserState.INACTIVE -> Triple(R.string.main_title_inactive_member, null, null)

--- a/app/src/main/java/org/sopt/official/util/GenerationExt.kt
+++ b/app/src/main/java/org/sopt/official/util/GenerationExt.kt
@@ -8,17 +8,16 @@ import kotlinx.datetime.toLocalDate
 
 private const val BASE_DATE = "2007-03-01"
 
-fun getGenerationStartDate(
-        generation: Int,
-        period: Int = 6,
-        from: LocalDate = BASE_DATE.toLocalDate()
+fun calculateGenerationStartDate(
+    generation: Int,
+    period: Int = 6,
+    from: LocalDate = BASE_DATE.toLocalDate()
 ): LocalDate {
     val monthsToTake = generation * period
     return from.plus(monthsToTake, DateTimeUnit.MONTH)
 }
 
-fun computeMothUntilNow(generation: Int, currentDate: LocalDate): Int {
-    val generationStartDate = getGenerationStartDate(generation)
-    val diff = generationStartDate.periodUntil(currentDate)
+fun calculateDurationOfGeneration(start: LocalDate, end: LocalDate): Int {
+    val diff = start.periodUntil(end)
     return diff.months + diff.years * 12
 }

--- a/app/src/main/java/org/sopt/official/util/GenerationExt.kt
+++ b/app/src/main/java/org/sopt/official/util/GenerationExt.kt
@@ -1,26 +1,20 @@
 package org.sopt.official.util
 
-import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
 import kotlinx.datetime.periodUntil
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDate
-import kotlinx.datetime.toLocalDateTime
 
 const val BASE_DATE = "2007-03-01"
 
-fun getGeneration(generation: Int): LocalDate {
-    val baseLocalDate = BASE_DATE.toLocalDate()
-    val monthsBetweenGenerations = 6
+fun getGenerationStartDate(generation: Int, baseLocalDate: LocalDate = BASE_DATE.toLocalDate(), monthsBetweenGenerations: Int = 6): LocalDate {
     val monthsToTake = generation * monthsBetweenGenerations
     return baseLocalDate.plus(monthsToTake, DateTimeUnit.MONTH)
 }
 
-fun computeMothUntilNow(generation: Int): Int {
-    val currentTime = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
-    val generationDate = getGeneration(generation)
-    val diff = generationDate.periodUntil(currentTime)
+fun computeMothUntilNow(generation: Int, currentTime: LocalDate): Int {
+    val generationStartDate = getGenerationStartDate(generation)
+    val diff = generationStartDate.periodUntil(currentTime)
     return diff.months + diff.years * 12
 }

--- a/app/src/main/java/org/sopt/official/util/GenerationExt.kt
+++ b/app/src/main/java/org/sopt/official/util/GenerationExt.kt
@@ -6,15 +6,19 @@ import kotlinx.datetime.periodUntil
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDate
 
-const val BASE_DATE = "2007-03-01"
+private const val BASE_DATE = "2007-03-01"
 
-fun getGenerationStartDate(generation: Int, baseLocalDate: LocalDate = BASE_DATE.toLocalDate(), monthsBetweenGenerations: Int = 6): LocalDate {
-    val monthsToTake = generation * monthsBetweenGenerations
-    return baseLocalDate.plus(monthsToTake, DateTimeUnit.MONTH)
+fun getGenerationStartDate(
+        generation: Int,
+        period: Int = 6,
+        from: LocalDate = BASE_DATE.toLocalDate()
+): LocalDate {
+    val monthsToTake = generation * period
+    return from.plus(monthsToTake, DateTimeUnit.MONTH)
 }
 
-fun computeMothUntilNow(generation: Int, currentTime: LocalDate): Int {
+fun computeMothUntilNow(generation: Int, currentDate: LocalDate): Int {
     val generationStartDate = getGenerationStartDate(generation)
-    val diff = generationStartDate.periodUntil(currentTime)
+    val diff = generationStartDate.periodUntil(currentDate)
     return diff.months + diff.years * 12
 }

--- a/app/src/main/java/org/sopt/official/util/GenerationExt.kt
+++ b/app/src/main/java/org/sopt/official/util/GenerationExt.kt
@@ -9,11 +9,13 @@ import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDate
 import kotlinx.datetime.toLocalDateTime
 
+const val BASE_DATE = "2007-03-01"
+
 fun getGeneration(generation: Int): LocalDate {
-    val baseDate = "2007-03-01".toLocalDate()
+    val baseLocalDate = BASE_DATE.toLocalDate()
     val monthsBetweenGenerations = 6
-    val monthsToTake = (generation - 0) * monthsBetweenGenerations
-    return baseDate.plus(monthsToTake, DateTimeUnit.MONTH)
+    val monthsToTake = generation * monthsBetweenGenerations
+    return baseLocalDate.plus(monthsToTake, DateTimeUnit.MONTH)
 }
 
 fun computeMothUntilNow(generation: Int): Int {

--- a/app/src/main/java/org/sopt/official/util/GenerationExt.kt
+++ b/app/src/main/java/org/sopt/official/util/GenerationExt.kt
@@ -1,33 +1,20 @@
 package org.sopt.official.util
 
 import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.periodUntil
-import kotlinx.datetime.toKotlinLocalDate
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDate
 import kotlinx.datetime.toLocalDateTime
-import java.time.format.DateTimeFormatter
 
-private val DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy.MM.dd")
-fun getGeneration(generation: Int): LocalDate =
-        java.time.LocalDate.parse(
-                when (generation) {
-                    32 -> "2023.03.01"
-                    31 -> "2022.09.01"
-                    30 -> "2022.03.01"
-                    29 -> "2021.09.01"
-                    28 -> "2021.03.01"
-                    27 -> "2020.09.01"
-                    26 -> "2020.03.01"
-                    25 -> "2019.09.01"
-                    24 -> "2019.03.01"
-                    23 -> "2018.09.01"
-                    22 -> "2018.03.01"
-                    21 -> "2017.09.01"
-                    else -> "2017.03.01"
-                },
-                DATE_FORMAT
-        ).toKotlinLocalDate()
+fun getGeneration(generation: Int): LocalDate {
+    val baseDate = "2007-03-01".toLocalDate()
+    val monthsBetweenGenerations = 6
+    val monthsToSubtract = (generation - 0) * monthsBetweenGenerations
+    return baseDate.plus(monthsToSubtract, DateTimeUnit.MONTH)
+}
 
 fun computeMothUntilNow(generation: Int): Int {
     val currentTime = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date

--- a/app/src/main/java/org/sopt/official/util/GenerationExt.kt
+++ b/app/src/main/java/org/sopt/official/util/GenerationExt.kt
@@ -12,8 +12,8 @@ import kotlinx.datetime.toLocalDateTime
 fun getGeneration(generation: Int): LocalDate {
     val baseDate = "2007-03-01".toLocalDate()
     val monthsBetweenGenerations = 6
-    val monthsToSubtract = (generation - 0) * monthsBetweenGenerations
-    return baseDate.plus(monthsToSubtract, DateTimeUnit.MONTH)
+    val monthsToTake = (generation - 0) * monthsBetweenGenerations
+    return baseDate.plus(monthsToTake, DateTimeUnit.MONTH)
 }
 
 fun computeMothUntilNow(generation: Int): Int {

--- a/app/src/main/java/org/sopt/official/util/GenerationExt.kt
+++ b/app/src/main/java/org/sopt/official/util/GenerationExt.kt
@@ -1,36 +1,37 @@
 package org.sopt.official.util
 
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.Period
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.periodUntil
+import kotlinx.datetime.toKotlinLocalDate
+import kotlinx.datetime.toLocalDateTime
 import java.time.format.DateTimeFormatter
-import java.util.Date
 
 private val DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy.MM.dd")
 fun getGeneration(generation: Int): LocalDate =
-    LocalDate.parse(
-        when (generation) {
-            32 -> "2023.03.01"
-            31 -> "2022.09.01"
-            30 -> "2022.03.01"
-            29 -> "2021.09.01"
-            28 -> "2021.03.01"
-            27 -> "2020.09.01"
-            26 -> "2020.03.01"
-            25 -> "2019.09.01"
-            24 -> "2019.03.01"
-            23 -> "2018.09.01"
-            22 -> "2018.03.01"
-            21 -> "2017.09.01"
-            else -> "2017.03.01"
-        },
-        DATE_FORMAT
-    )
+        java.time.LocalDate.parse(
+                when (generation) {
+                    32 -> "2023.03.01"
+                    31 -> "2022.09.01"
+                    30 -> "2022.03.01"
+                    29 -> "2021.09.01"
+                    28 -> "2021.03.01"
+                    27 -> "2020.09.01"
+                    26 -> "2020.03.01"
+                    25 -> "2019.09.01"
+                    24 -> "2019.03.01"
+                    23 -> "2018.09.01"
+                    22 -> "2018.03.01"
+                    21 -> "2017.09.01"
+                    else -> "2017.03.01"
+                },
+                DATE_FORMAT
+        ).toKotlinLocalDate()
 
 fun computeMothUntilNow(generation: Int): Int {
-    val currentTime = LocalDateTime.now().toLocalDate()
+    val currentTime = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
     val generationDate = getGeneration(generation)
-
-    val diff = Period.between(generationDate, currentTime)
+    val diff = generationDate.periodUntil(currentTime)
     return diff.months + diff.years * 12
 }

--- a/app/src/main/java/org/sopt/official/util/TimeExt.kt
+++ b/app/src/main/java/org/sopt/official/util/TimeExt.kt
@@ -1,0 +1,11 @@
+package org.sopt.official.util
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+fun getCurrentInstant(): Instant = Clock.System.now()
+
+fun Instant.toDefaultLocalDate(): LocalDate = toLocalDateTime(TimeZone.currentSystemDefault()).date

--- a/app/src/main/java/org/sopt/official/util/TimeExt.kt
+++ b/app/src/main/java/org/sopt/official/util/TimeExt.kt
@@ -6,6 +6,6 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
-fun getCurrentInstant(): Instant = Clock.System.now()
+fun Instant.Companion.systemNow(): Instant = Clock.System.now()
 
 fun Instant.toDefaultLocalDate(): LocalDate = toLocalDateTime(TimeZone.currentSystemDefault()).date

--- a/app/src/test/java/org/sopt/official/JsonObjectTest.kt
+++ b/app/src/test/java/org/sopt/official/JsonObjectTest.kt
@@ -1,14 +1,12 @@
 package org.sopt.official
 
 import com.google.common.truth.Truth.assertThat
-import kotlinx.datetime.toLocalDate
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.sopt.official.util.getGeneration
 
 class JsonObjectTest {
     @Test
@@ -26,18 +24,5 @@ class JsonObjectTest {
 
         // then
         assertThat(message).isEqualTo("1차 출석이 이미 종료되었습니다.")
-    }
-
-    @Test
-    fun testGetGeneration() {
-        // given
-        val generation = 32
-        val expectedDate = "2023-03-01".toLocalDate()
-
-        // when
-        val actualDate = getGeneration(generation)
-
-        // then
-        assertThat(actualDate).isEqualTo(expectedDate)
     }
 }

--- a/app/src/test/java/org/sopt/official/JsonObjectTest.kt
+++ b/app/src/test/java/org/sopt/official/JsonObjectTest.kt
@@ -1,12 +1,14 @@
 package org.sopt.official
 
 import com.google.common.truth.Truth.assertThat
+import kotlinx.datetime.toLocalDate
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.sopt.official.util.getGeneration
 
 class JsonObjectTest {
     @Test
@@ -21,8 +23,21 @@ class JsonObjectTest {
 
         // when
         val message = Json.parseToJsonElement(json).jsonObject["message"]?.jsonPrimitive?.contentOrNull
-        
+
         // then
         assertThat(message).isEqualTo("1차 출석이 이미 종료되었습니다.")
+    }
+
+    @Test
+    fun testGetGeneration() {
+        // given
+        val generation = 32
+        val expectedDate = "2023-03-01".toLocalDate()
+
+        // when
+        val actualDate = getGeneration(generation)
+
+        // then
+        assertThat(actualDate).isEqualTo(expectedDate)
     }
 }

--- a/app/src/test/java/org/sopt/official/KotlinxDateTimeTest.kt
+++ b/app/src/test/java/org/sopt/official/KotlinxDateTimeTest.kt
@@ -40,16 +40,16 @@ class KotlinxDateTimeTest {
     companion object {
         @JvmStatic
         fun generationStartDateList() = listOf(
-                Arguments.of(30, "2022-03-01".toLocalDate()),
-                Arguments.of(31, "2022-09-01".toLocalDate()),
-                Arguments.of(32, "2023-03-01".toLocalDate())
+            Arguments.of(30, "2022-03-01".toLocalDate()),
+            Arguments.of(31, "2022-09-01".toLocalDate()),
+            Arguments.of(32, "2023-03-01".toLocalDate())
         )
 
         @JvmStatic
         fun generationLastMonthList() = listOf(
-                Arguments.of(30, 14),
-                Arguments.of(31, 8),
-                Arguments.of(32, 2)
+            Arguments.of(30, 14),
+            Arguments.of(31, 8),
+            Arguments.of(32, 2)
         )
     }
 }

--- a/app/src/test/java/org/sopt/official/KotlinxDateTimeTest.kt
+++ b/app/src/test/java/org/sopt/official/KotlinxDateTimeTest.kt
@@ -1,0 +1,48 @@
+package org.sopt.official
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.periodUntil
+import kotlinx.datetime.toLocalDate
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.sopt.official.util.getGeneration
+
+class KotlinxDateTimeTest {
+
+    @Test
+    @DisplayName("getGeneration 함수 파라메터에 SOPT 기수(1~32)를 넣게 되면 해당 기수의 시작 날짜를 반환한다")
+    fun testGetGeneration() {
+        // given
+        val generation = 32
+        val expectedDate = "2023-03-01".toLocalDate()
+
+        // when
+        val actualDate = getGeneration(generation)
+
+        // then
+        assertThat(actualDate).isEqualTo(expectedDate)
+    }
+
+    @Test
+    @DisplayName("computeMothUntilNow 함수 파라메터에 SOPT 기수(1~32)를 넣게 되면 해당 기수의 시작 날짜부터 현재까지의 개월 수를 반환한다")
+    fun testComputeMothUntilNow() {
+        // given
+        val generation = 32
+        val currentTime = "2023-05-17".toLocalDate()
+        val expectMonth = 2
+
+
+        // when
+        val actualMonth = computeMothUntilNow(generation, currentTime)
+
+        // then
+        assertThat(actualMonth).isEqualTo(expectMonth)
+    }
+
+    private fun computeMothUntilNow(generation: Int, currentTime: LocalDate): Int {
+        val generationDate = getGeneration(generation)
+        val diff = generationDate.periodUntil(currentTime)
+        return diff.months + diff.years * 12
+    }
+}

--- a/app/src/test/java/org/sopt/official/KotlinxDateTimeTest.kt
+++ b/app/src/test/java/org/sopt/official/KotlinxDateTimeTest.kt
@@ -4,37 +4,52 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toLocalDate
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Test
-import org.sopt.official.util.computeMothUntilNow
-import org.sopt.official.util.getGenerationStartDate
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.sopt.official.util.calculateDurationOfGeneration
+import org.sopt.official.util.calculateGenerationStartDate
 
 class KotlinxDateTimeTest {
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("generationStartDateList")
     @DisplayName("SOPT 기수(1~32)를 입력하면 해당 기수의 시작 날짜를 반환한다")
-    fun testGetGeneration() {
-        // given
-        val generation = 32
-        val expectedDate = "2023-03-01".toLocalDate()
-
+    fun testGetGeneration(generation: Int, expectedDate: LocalDate) {
         // when
-        val actualDate = getGenerationStartDate(generation)
+        val actualDate = calculateGenerationStartDate(generation)
 
         // then
         assertThat(actualDate).isEqualTo(expectedDate)
     }
 
-    @Test
-    @DisplayName("SOPT 기수(1~32)를 입력하면 해당 기수의 시작 날짜부터 입력한 날짜까지의 개월 수를 반환한다")
-    fun testComputeMothUntilNow() {
+    @ParameterizedTest
+    @MethodSource("generationLastMonthList")
+    @DisplayName("SOPT 기수(1~32)를 입력하면 해당 기수의 시작 날짜부터 입력한 날짜까지의 개월 수를 반환한다 (30~32기 테스트)")
+    fun testComputeMothUntilNow(generation: Int, expectMonth: Int) {
         // given
-        val generation = 32 // 32기 시작 날짜: 2023-03-01
-        val expectMonth = 2
+        val actualDate = calculateGenerationStartDate(generation)
 
         // when
-        val actualMonth = computeMothUntilNow(generation, LocalDate(2023, 5, 17))
+        val actualMonth = calculateDurationOfGeneration(actualDate, LocalDate(2023, 5, 17))
 
         // then
         assertThat(actualMonth).isEqualTo(expectMonth)
+    }
+
+    companion object {
+        @JvmStatic
+        fun generationStartDateList() = listOf(
+                Arguments.of(30, "2022-03-01".toLocalDate()),
+                Arguments.of(31, "2022-09-01".toLocalDate()),
+                Arguments.of(32, "2023-03-01".toLocalDate())
+        )
+
+        @JvmStatic
+        fun generationLastMonthList() = listOf(
+                Arguments.of(30, 14),
+                Arguments.of(31, 8),
+                Arguments.of(32, 2)
+        )
     }
 }

--- a/app/src/test/java/org/sopt/official/KotlinxDateTimeTest.kt
+++ b/app/src/test/java/org/sopt/official/KotlinxDateTimeTest.kt
@@ -2,11 +2,11 @@ package org.sopt.official
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.periodUntil
 import kotlinx.datetime.toLocalDate
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.sopt.official.util.getGeneration
+import org.sopt.official.util.computeMothUntilNow
+import org.sopt.official.util.getGenerationStartDate
 
 class KotlinxDateTimeTest {
 
@@ -18,31 +18,23 @@ class KotlinxDateTimeTest {
         val expectedDate = "2023-03-01".toLocalDate()
 
         // when
-        val actualDate = getGeneration(generation)
+        val actualDate = getGenerationStartDate(generation)
 
         // then
         assertThat(actualDate).isEqualTo(expectedDate)
     }
 
     @Test
-    @DisplayName("computeMothUntilNow 함수 파라메터에 SOPT 기수(1~32)를 넣게 되면 해당 기수의 시작 날짜부터 현재까지의 개월 수를 반환한다")
+    @DisplayName("computeMothUntilNow 함수 파라메터에 SOPT 기수(1~32)를 넣게 되면 해당 기수의 시작 날짜부터 2023-05-17까지의 개월 수를 반환한다")
     fun testComputeMothUntilNow() {
         // given
         val generation = 32
-        val currentTime = "2023-05-17".toLocalDate()
         val expectMonth = 2
 
-
         // when
-        val actualMonth = computeMothUntilNow(generation, currentTime)
+        val actualMonth = computeMothUntilNow(generation, LocalDate(2023, 5, 17))
 
         // then
         assertThat(actualMonth).isEqualTo(expectMonth)
-    }
-
-    private fun computeMothUntilNow(generation: Int, currentTime: LocalDate): Int {
-        val generationDate = getGeneration(generation)
-        val diff = generationDate.periodUntil(currentTime)
-        return diff.months + diff.years * 12
     }
 }

--- a/app/src/test/java/org/sopt/official/KotlinxDateTimeTest.kt
+++ b/app/src/test/java/org/sopt/official/KotlinxDateTimeTest.kt
@@ -11,7 +11,7 @@ import org.sopt.official.util.getGenerationStartDate
 class KotlinxDateTimeTest {
 
     @Test
-    @DisplayName("getGeneration 함수 파라메터에 SOPT 기수(1~32)를 넣게 되면 해당 기수의 시작 날짜를 반환한다")
+    @DisplayName("SOPT 기수(1~32)를 입력하면 해당 기수의 시작 날짜를 반환한다")
     fun testGetGeneration() {
         // given
         val generation = 32
@@ -25,10 +25,10 @@ class KotlinxDateTimeTest {
     }
 
     @Test
-    @DisplayName("computeMothUntilNow 함수 파라메터에 SOPT 기수(1~32)를 넣게 되면 해당 기수의 시작 날짜부터 2023-05-17까지의 개월 수를 반환한다")
+    @DisplayName("SOPT 기수(1~32)를 입력하면 해당 기수의 시작 날짜부터 입력한 날짜까지의 개월 수를 반환한다")
     fun testComputeMothUntilNow() {
         // given
-        val generation = 32
+        val generation = 32 // 32기 시작 날짜: 2023-03-01
         val expectMonth = 2
 
         // when


### PR DESCRIPTION
## What is this issue?
- [x] close #204 java 의존성을 떨어뜨리고자 하는 목적으로 java-time을 kotlinx-datetime 패키지로 변환

## Reference
- [x] [kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)

## 추가 확인 사항
각 레벨별로 커밋을 나누어 놓았습니다. 확인해주시면 감사하겠습니다.