### PR TITLE
[Feature/throttle-click] : #239 add throttle click 

### DIFF
--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
@@ -83,11 +83,11 @@ class MissionDetailViewModel @Inject constructor(
     val isDeleteDialogVisible = uiState.map { it.isDeleteDialogVisible }
     val isError = uiState.map { it.isError }
 
-    private val submitFlow = MutableSharedFlow<Unit>()
+    private val submitEvent = MutableSharedFlow<Unit>()
 
     init {
         viewModelScope.launch {
-            submitFlow.debounce(500).collect {
+            submitEvent.debounce(500).collect {
                 handleSubmit()
             }
         }
@@ -183,7 +183,7 @@ class MissionDetailViewModel @Inject constructor(
 
     fun onSubmit() {
         viewModelScope.launch {
-            submitFlow.emit(Unit)
+            submitEvent.emit(Unit)
         }
     }
 

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
@@ -18,8 +18,10 @@ package org.sopt.official.stamp.feature.mission.detail
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
@@ -80,6 +82,16 @@ class MissionDetailViewModel @Inject constructor(
     val isDeleteSuccess = uiState.map { it.isDeleteSuccess }
     val isDeleteDialogVisible = uiState.map { it.isDeleteDialogVisible }
     val isError = uiState.map { it.isError }
+
+    private val submitFlow = MutableSharedFlow<Unit>()
+
+    init {
+        viewModelScope.launch {
+            submitFlow.debounce(500).collect {
+                handleSubmit()
+            }
+        }
+    }
 
     fun initMissionState(
         id: Int,
@@ -170,6 +182,12 @@ class MissionDetailViewModel @Inject constructor(
     }
 
     fun onSubmit() {
+        viewModelScope.launch {
+            submitFlow.emit(Unit)
+        }
+    }
+
+    private suspend fun handleSubmit() {
         viewModelScope.launch {
             val currentState = uiState.value
             Timber.d("MissionDetailViewModel onSubmit() $currentState")


### PR DESCRIPTION
## What is this issue?
- [x] close #239 SharedFlow를 통해 버튼을 동시에 여러 번 눌러도 첫 터치에 의한 서버통신만 가능하게 수정했습니다. 

## Reference
- [x] [SharedFlow](https://developer.android.com/kotlin/flow/stateflow-and-sharedflow?hl=ko)

### 주의 사항
뷰모델이 생성될 때마다 init 블록이 실행되므로, onSubmit() 함수에만 적용시키는 의도에는 비효율적일 수 있습니다. 하지만 다른 함수들에도 throttle 의 로직을 적용시키면 좋을 것 같아 init 블록을 통해 submit의 SharedFlow 상태를 변경시켰습니다. 