### PR TITLE
[feature/hilt-ksp] Apply ksp on hilt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,9 +105,6 @@ dependencies {
 
     implementation(libs.bundles.mavericks)
 
-    implementation(libs.hilt)
-    kapt(libs.hilt.kapt)
-
     implementation(platform(libs.firebase))
     implementation(libs.bundles.firebase)
     implementation(libs.sentry.compose)

--- a/build-logic/convention/src/main/kotlin/org/sopt/official/plugin/AndroidHiltPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/org/sopt/official/plugin/AndroidHiltPlugin.kt
@@ -9,15 +9,16 @@ import org.gradle.kotlin.dsl.getByType
 class AndroidHiltPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         with(plugins) {
+            apply("com.google.devtools.ksp")
             apply("com.google.dagger.hilt.android")
         }
 
         val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
         dependencies {
             "implementation"(libs.findLibrary("hilt").get())
-            "kapt"(libs.findLibrary("hilt.kapt").get())
+            "ksp"(libs.findLibrary("hilt.ksp").get())
             "testImplementation"(libs.findLibrary("hilt.testing").get())
-            "kaptTest"(libs.findLibrary("hilt.testing.compiler").get())
+            "kspTest"(libs.findLibrary("hilt.testing.compiler").get())
         }
     }
 }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/di/ConfigModule.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/di/ConfigModule.kt
@@ -26,8 +26,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import org.sopt.official.stamp.BuildConfig
 import org.sopt.official.stamp.di.constant.Soptamp
-import org.sopt.stamp.di.constant.Constant
-import org.sopt.stamp.di.constant.Strings
+import org.sopt.official.stamp.di.constant.Constant
+import org.sopt.official.stamp.di.constant.Strings
 import timber.log.Timber
 import java.security.KeyStore
 import javax.inject.Singleton

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/di/ConstantModule.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/di/ConstantModule.kt
@@ -20,8 +20,8 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import org.sopt.official.stamp.BuildConfig
-import org.sopt.stamp.di.constant.Constant
-import org.sopt.stamp.di.constant.Strings
+import org.sopt.official.stamp.di.constant.Constant
+import org.sopt.official.stamp.di.constant.Strings
 import javax.inject.Singleton
 
 @Module
@@ -29,11 +29,6 @@ import javax.inject.Singleton
 object ConstantModule {
     @Provides
     @Singleton
-    @Strings(Constant.SOPTAMP_API_KEY)
-    fun provideBaseUrl() = BuildConfig.SOPTAMP_API_KEY
-
-    @Provides
-    @Singleton
     @Strings(Constant.SOPTAMP_DATA_STORE)
-    fun provideSoptampDataStoreKey() = BuildConfig.SOPTAMP_DATA_STORE_KEY
+    fun provideSoptampDataStoreKey(): String = BuildConfig.SOPTAMP_DATA_STORE_KEY
 }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/di/constant/Constant.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/di/constant/Constant.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.sopt.stamp.di.constant
+package org.sopt.official.stamp.di.constant
 
 import javax.inject.Qualifier
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -149,7 +149,7 @@ mavericks-navigation = { module = "com.airbnb.android:mavericks-navigation", ver
 mavericks-mockable = { module = "com.airbnb.android:mavericks-mocking", version.ref = "mavericks" }
 
 hilt = { module = "com.google.dagger:hilt-android", version.ref = "dagger-hilt" }
-hilt-kapt = { module = "com.google.dagger:hilt-compiler", version.ref = "dagger-hilt" }
+hilt-ksp = { module = "com.google.dagger:hilt-compiler", version.ref = "dagger-hilt" }
 hilt-plugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "dagger-hilt" }
 hilt-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "dagger-hilt" }
 hilt-testing-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "dagger-hilt" }


### PR DESCRIPTION
## What is this issue?
- [x] hilt 2.48 버전 이후로 ksp 적용이 가능해져서 ksp 적용을 해봤습니다. 빌드 시간 대폭 감축이 예상됩니다(포포리에서는 빌드속도가 10분 -> 7분 정도로 바뀌었습니다)
- [x] 그런데 databinding은 여전히 kapt를 사용하고 있어서 kapt를 완전히 사용하지 않으려면 databinding 사용 코드를 제거해야할 것 같은데, 시간 되시면 데이터 바인딩 코드는 앞으로 사용을 자제해주시고 사용하고 있는 코드는 viewbinding 기반 혹은 compose로 전환해주시면 좋을 것 같습니다. @hjh1161514 @yxnsx @kimdahyee 

