### PR TITLE
[feature/soptamp-generation-ranking] 기수별 랭킹 UI 구현

### DIFF
--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/designsystem/component/button/SoptampIconButton.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/designsystem/component/button/SoptampIconButton.kt
@@ -56,13 +56,14 @@ import org.sopt.official.stamp.designsystem.style.SoptTheme
  * */
 @Composable
 fun SoptampIconButton(
+    modifier: Modifier = Modifier,
     imageVector: ImageVector,
     contentDescription: String? = null,
     tint: Color = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
     onClick: () -> Unit = {}
 ) {
     Row(
-        modifier = Modifier.noRippleClickable { onClick() }
+        modifier = modifier.noRippleClickable { onClick() }
     ) {
         Icon(
             imageVector = imageVector,

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/designsystem/component/button/SoptampIconButton.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/designsystem/component/button/SoptampIconButton.kt
@@ -56,8 +56,8 @@ import org.sopt.official.stamp.designsystem.style.SoptTheme
  * */
 @Composable
 fun SoptampIconButton(
-    modifier: Modifier = Modifier,
     imageVector: ImageVector,
+    modifier: Modifier = Modifier,
     contentDescription: String? = null,
     tint: Color = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
     onClick: () -> Unit = {}

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankingScreen.kt
@@ -166,7 +166,7 @@ fun RankingScreen(
                 state = listState,
                 modifier = Modifier.padding(defaultPadding),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
-                contentPadding = PaddingValues(bottom = 70.dp)
+                contentPadding = PaddingValues(bottom = 80.dp)
             ) {
                 item {
                     TopRankerList(

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/TopRankerItem.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/TopRankerItem.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -37,18 +38,22 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.sopt.official.stamp.R
+import org.sopt.official.stamp.designsystem.component.button.SoptampIconButton
 import org.sopt.official.stamp.designsystem.component.util.noRippleClickable
+import org.sopt.official.stamp.designsystem.style.Gray600
+import org.sopt.official.stamp.designsystem.style.Gray800
 import org.sopt.official.stamp.designsystem.style.SoptTheme
 import org.sopt.official.stamp.feature.ranking.model.RankerUiModel
 
 @Composable
-fun TopRankerItem(ranker: RankerUiModel, height: Dp, onClick: (RankerUiModel) -> Unit = {}) {
+fun TopRankerItem(ranker: RankerUiModel, height: Dp, onClick: (RankerUiModel) -> Unit = {}, onClickTopRankerBubble: () -> Unit = {}) {
     Column(
         modifier = Modifier.noRippleClickable { onClick(ranker) },
         verticalArrangement = Arrangement.Bottom,
@@ -57,10 +62,10 @@ fun TopRankerItem(ranker: RankerUiModel, height: Dp, onClick: (RankerUiModel) ->
         TopRankBarOfRankText(rank = ranker.rank)
         TopRankBarOfGraph(rank = ranker.rank, score = ranker.score, height = height)
         Spacer(modifier = Modifier.size(10.dp))
-        Text(
-            text = ranker.nickname,
-            style = SoptTheme.typography.h3,
-            color = Color.Black
+        TopRankBarOfName(
+            rank = ranker.rank,
+            nickname = ranker.nickname,
+            onClickTopRankerBubble = onClickTopRankerBubble
         )
     }
 }
@@ -106,6 +111,38 @@ fun TopRankBarOfGraph(rank: Int, score: Int, height: Dp) {
     }
 }
 
+@Composable
+fun TopRankBarOfName(rank: Int, nickname: String, onClickTopRankerBubble: () -> Unit = {}) {
+    Box(
+        modifier = Modifier
+            .noRippleClickable {
+                onClickTopRankerBubble()
+            }
+            .size(width = 97.dp, height = 32.dp)
+            .background(
+                color = getRankBackgroundColor(rank),
+                shape = RoundedCornerShape(50.dp)
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = nickname,
+                maxLines = 1,
+                style = SoptTheme.typography.sub3,
+                color = Gray800
+            )
+            SoptampIconButton(
+                modifier = Modifier.size(16.dp),
+                imageVector = ImageVector.vectorResource(id = R.drawable.right_forward),
+                tint = Gray600
+            )
+        }
+    }
+}
+
 @Preview
 @Composable
 fun PreviewTopRankerItem() {
@@ -113,7 +150,7 @@ fun PreviewTopRankerItem() {
         TopRankerItem(
             ranker = RankerUiModel(
                 rank = 1,
-                nickname = "jinsu",
+                nickname = "디자인김땡땡",
                 score = 1000
             ),
             height = 150.dp

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/TopRankerItem.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/TopRankerItem.kt
@@ -62,7 +62,7 @@ fun TopRankerItem(ranker: RankerUiModel, height: Dp, onClick: (RankerUiModel) ->
         TopRankBarOfRankText(rank = ranker.rank)
         TopRankBarOfGraph(rank = ranker.rank, score = ranker.score, height = height)
         Spacer(modifier = Modifier.size(10.dp))
-        TopRankBarOfName(
+        TopRankBarOfUserName(
             rank = ranker.rank,
             nickname = ranker.nickname,
             onClickTopRankerBubble = onClickTopRankerBubble
@@ -112,7 +112,7 @@ fun TopRankBarOfGraph(rank: Int, score: Int, height: Dp) {
 }
 
 @Composable
-fun TopRankBarOfName(rank: Int, nickname: String, onClickTopRankerBubble: () -> Unit = {}) {
+fun TopRankBarOfUserName(rank: Int, nickname: String, onClickTopRankerBubble: () -> Unit = {}) {
     Box(
         modifier = Modifier
             .noRippleClickable {

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/TopRankerList.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/TopRankerList.kt
@@ -91,9 +91,24 @@ fun TopRankerList(topRanker: RankersUiModel, onClickTopRankerBubble: (RankerUiMo
             val onClickRanker = { ranker: RankerUiModel ->
                 onClickRankerState = ranker
             }
-            TopRankerItem(ranker = topRanker.second, 110.dp, onClickRanker)
-            TopRankerItem(ranker = topRanker.first, 150.dp, onClickRanker)
-            TopRankerItem(ranker = topRanker.third, 70.dp, onClickRanker)
+            TopRankerItem(
+                ranker = topRanker.second,
+                height = 110.dp,
+                onClick = onClickRanker,
+                onClickTopRankerBubble = { onClickTopRankerBubble(topRanker.second) }
+            )
+            TopRankerItem(
+                ranker = topRanker.first,
+                height = 150.dp,
+                onClick = onClickRanker,
+                onClickTopRankerBubble = { onClickTopRankerBubble(topRanker.first) }
+            )
+            TopRankerItem(
+                ranker = topRanker.third,
+                height = 70.dp,
+                onClick = onClickRanker,
+                onClickTopRankerBubble = { onClickTopRankerBubble(topRanker.third) }
+            )
         }
     }
 }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/TopRankerList.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/TopRankerList.kt
@@ -63,10 +63,10 @@ fun TopRankerList(topRanker: RankersUiModel, onClickTopRankerBubble: (RankerUiMo
         modifier = Modifier
             .fillMaxWidth()
             .padding(
-                top = 8.dp,
-                bottom = 10.dp,
-                start = 9.dp,
-                end = 9.dp
+                top = 6.dp,
+                bottom = 11.dp,
+                start = 6.dp,
+                end = 6.dp
             ),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {


### PR DESCRIPTION
close #631 
## What is this issue?
- [x] 사용자 닉네임 컴포넌트 생성
- [x] 사용자 닉네임 onClick 이벤트 추가
- [x] TopRanker Column 범위 조정
- [x] FAB와 LazyColumn의 범위 조정

