### PR TITLE
[featuer/soptamp-toolcahin] add Kotlin jvmToolchain

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -9,6 +9,10 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
+kotlin {
+    jvmToolchain(17)
+}
+
 dependencies {
     compileOnly(libs.agp)
     compileOnly(libs.kotlin.gradleplugin)


### PR DESCRIPTION
## What is this issue?
- add kotlin tool chain 

## To Reviewers
`./gradlew spotlessApply`를 했는데 아래처럼 되네요... 왜그럴까요?
앱 실행은 잘 됩니다!
![image](https://github.com/sopt-makers/sopt-android/assets/52882799/77b41bb4-bfd1-4e1d-b1b0-15d8da05ce34)
