### PR TITLE
[feature/soptamp part ranking] Server 제외 구현 완료

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -9,6 +9,10 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
+kotlin {
+    jvmToolchain(17)
+}
+
 dependencies {
     compileOnly(libs.agp)
     compileOnly(libs.kotlin.gradleplugin)

--- a/feature/soptamp/build.gradle.kts
+++ b/feature/soptamp/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation(projects.core.common)
     implementation(projects.core.analytics)
     implementation(libs.kotlin.datetime)
+    implementation(libs.kotlin.collections.immutable)
     implementation(platform(libs.compose.bom))
     implementation(libs.bundles.compose)
     implementation(libs.compose.destination.core)

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/list/MissionListScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/list/MissionListScreen.kt
@@ -86,7 +86,6 @@ import org.sopt.official.stamp.feature.mission.model.MissionListUiModel
 import org.sopt.official.stamp.feature.mission.model.MissionNavArgs
 import org.sopt.official.stamp.feature.mission.model.MissionUiModel
 import org.sopt.official.stamp.feature.mission.model.toArgs
-import org.sopt.official.stamp.feature.ranking.part.PartRankingScreen
 
 @MissionNavGraph(true)
 @Destination("list")

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/list/MissionListScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/list/MissionListScreen.kt
@@ -64,6 +64,10 @@ import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.ramcosta.composedestinations.result.NavResult
 import com.ramcosta.composedestinations.result.ResultRecipient
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.immutableListOf
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import org.sopt.official.domain.soptamp.MissionLevel
 import org.sopt.official.domain.soptamp.error.Error
 import org.sopt.official.domain.soptamp.model.MissionsFilter
@@ -125,7 +129,7 @@ fun MissionListScreen(
             is MissionsState.Success -> MissionListScreen(
                 nickname = nickname,
                 missionListUiModel = (state as MissionsState.Success).missionListUiModel,
-                menuTexts = MissionsFilter.getTitleOfMissionsList(),
+                menuTexts = MissionsFilter.getTitleOfMissionsList().toImmutableList(),
                 onMenuClick = { filter -> missionsViewModel.fetchMissions(filter = filter) },
                 onMissionItemClick = { item ->
                     navigator.navigate(
@@ -144,7 +148,7 @@ fun MissionListScreen(
 fun MissionListScreen(
     nickname: String,
     missionListUiModel: MissionListUiModel,
-    menuTexts: List<String>,
+    menuTexts: ImmutableList<String>,// List<String>,
     onMenuClick: (String) -> Unit = {},
     onMissionItemClick: (item: MissionNavArgs) -> Unit = {},
     onPartRankingButtonClick: () -> Unit = {},
@@ -383,7 +387,7 @@ fun PreviewMissionListScreen() {
         MissionListScreen(
             nickname = "Nunu",
             missionListUiModel,
-            listOf("전체 미션", "완료 미션", "미완료 미션")
+            persistentListOf("전체 미션", "완료 미션", "미완료 미션")
         )
     }
 }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/list/MissionListScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/list/MissionListScreen.kt
@@ -78,6 +78,7 @@ import org.sopt.official.stamp.designsystem.component.topappbar.SoptTopAppBar
 import org.sopt.official.stamp.designsystem.style.SoptTheme
 import org.sopt.official.stamp.feature.destinations.MissionDetailScreenDestination
 import org.sopt.official.stamp.feature.destinations.OnboardingScreenDestination
+import org.sopt.official.stamp.feature.destinations.PartRankingScreenDestination
 import org.sopt.official.stamp.feature.destinations.RankingScreenDestination
 import org.sopt.official.stamp.feature.mission.MissionsState
 import org.sopt.official.stamp.feature.mission.MissionsViewModel
@@ -85,6 +86,7 @@ import org.sopt.official.stamp.feature.mission.model.MissionListUiModel
 import org.sopt.official.stamp.feature.mission.model.MissionNavArgs
 import org.sopt.official.stamp.feature.mission.model.MissionUiModel
 import org.sopt.official.stamp.feature.mission.model.toArgs
+import org.sopt.official.stamp.feature.ranking.part.PartRankingScreen
 
 @MissionNavGraph(true)
 @Destination("list")
@@ -131,8 +133,8 @@ fun MissionListScreen(
                         MissionDetailScreenDestination(item)
                     )
                 },
-                onAllRankingButtonClick = { navigator.navigate(RankingScreenDestination(false)) },
-                onCurrentRankingButtonClick = { navigator.navigate(RankingScreenDestination(true)) },
+                onPartRankingButtonClick = { navigator.navigate(PartRankingScreenDestination) },
+                onCurrentRankingButtonClick = { navigator.navigate(RankingScreenDestination("34기")) },
                 onOnboadingButtonClick = { navigator.navigate(OnboardingScreenDestination) }
             )
         }
@@ -146,7 +148,7 @@ fun MissionListScreen(
     menuTexts: List<String>,
     onMenuClick: (String) -> Unit = {},
     onMissionItemClick: (item: MissionNavArgs) -> Unit = {},
-    onAllRankingButtonClick: () -> Unit = {},
+    onPartRankingButtonClick: () -> Unit = {},
     onCurrentRankingButtonClick: () -> Unit = {},
     onOnboadingButtonClick: () -> Unit = {},
 ) {
@@ -161,10 +163,10 @@ fun MissionListScreen(
         },
         floatingActionButton = {
             SoptampSegmentedFloatingButton(
-                option1 = "전체 랭킹",
-                option2 = "34기 랭킹",
-                onClickFirstOption = onAllRankingButtonClick,
-                onClickSecondOption = onCurrentRankingButtonClick
+                option1 = "34기 랭킹",
+                option2 = "파트별 랭킹",
+                onClickFirstOption = onCurrentRankingButtonClick,
+                onClickSecondOption = onPartRankingButtonClick
             )
         },
         floatingActionButtonPosition = FabPosition.Center

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/list/MissionListScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/list/MissionListScreen.kt
@@ -65,7 +65,6 @@ import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.ramcosta.composedestinations.result.NavResult
 import com.ramcosta.composedestinations.result.ResultRecipient
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.immutableListOf
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import org.sopt.official.domain.soptamp.MissionLevel
@@ -148,7 +147,7 @@ fun MissionListScreen(
 fun MissionListScreen(
     nickname: String,
     missionListUiModel: MissionListUiModel,
-    menuTexts: ImmutableList<String>,// List<String>,
+    menuTexts: ImmutableList<String>, // List<String>,
     onMenuClick: (String) -> Unit = {},
     onMissionItemClick: (item: MissionNavArgs) -> Unit = {},
     onPartRankingButtonClick: () -> Unit = {},

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/list/MissionListScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/list/MissionListScreen.kt
@@ -147,7 +147,7 @@ fun MissionListScreen(
 fun MissionListScreen(
     nickname: String,
     missionListUiModel: MissionListUiModel,
-    menuTexts: ImmutableList<String>, // List<String>,
+    menuTexts: ImmutableList<String>,
     onMenuClick: (String) -> Unit = {},
     onMissionItemClick: (item: MissionNavArgs) -> Unit = {},
     onPartRankingButtonClick: () -> Unit = {},

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankColor.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankColor.kt
@@ -26,6 +26,7 @@ package org.sopt.official.stamp.feature.ranking
 
 import androidx.compose.runtime.Composable
 import org.sopt.official.stamp.designsystem.style.Gray300
+import org.sopt.official.stamp.designsystem.style.Gray400
 import org.sopt.official.stamp.designsystem.style.SoptTheme
 
 @Composable
@@ -33,7 +34,7 @@ fun getRankTextColor(rank: Int) = when (rank) {
     1 -> SoptTheme.colors.purple300
     2 -> SoptTheme.colors.pink300
     3 -> SoptTheme.colors.mint300
-    else -> SoptTheme.colors.onSurface50
+    else -> Gray400
 }
 
 @Composable

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankColor.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankColor.kt
@@ -34,7 +34,7 @@ fun getRankTextColor(rank: Int) = when (rank) {
     1 -> SoptTheme.colors.purple300
     2 -> SoptTheme.colors.pink300
     3 -> SoptTheme.colors.mint300
-    else -> Gray400
+    else -> SoptTheme.colors.onSurface40
 }
 
 @Composable
@@ -58,7 +58,7 @@ fun getRankBackgroundColor(rank: Int) = when (rank) {
     1 -> SoptTheme.colors.purple200
     2 -> SoptTheme.colors.pink200
     3 -> SoptTheme.colors.mint200
-    else -> Gray300
+    else ->  SoptTheme.colors.onSurface30
 }
 
 @Composable

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankColor.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankColor.kt
@@ -25,6 +25,7 @@
 package org.sopt.official.stamp.feature.ranking
 
 import androidx.compose.runtime.Composable
+import org.sopt.official.stamp.designsystem.style.Gray300
 import org.sopt.official.stamp.designsystem.style.SoptTheme
 
 @Composable
@@ -56,7 +57,7 @@ fun getRankBackgroundColor(rank: Int) = when (rank) {
     1 -> SoptTheme.colors.purple200
     2 -> SoptTheme.colors.pink200
     3 -> SoptTheme.colors.mint200
-    else -> SoptTheme.colors.onSurface5
+    else -> Gray300
 }
 
 @Composable

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankColor.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankColor.kt
@@ -25,8 +25,6 @@
 package org.sopt.official.stamp.feature.ranking
 
 import androidx.compose.runtime.Composable
-import org.sopt.official.stamp.designsystem.style.Gray300
-import org.sopt.official.stamp.designsystem.style.Gray400
 import org.sopt.official.stamp.designsystem.style.SoptTheme
 
 @Composable
@@ -58,7 +56,7 @@ fun getRankBackgroundColor(rank: Int) = when (rank) {
     1 -> SoptTheme.colors.purple200
     2 -> SoptTheme.colors.pink200
     3 -> SoptTheme.colors.mint200
-    else ->  SoptTheme.colors.onSurface30
+    else -> SoptTheme.colors.onSurface30
 }
 
 @Composable

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankListItem.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankListItem.kt
@@ -50,7 +50,8 @@ import org.sopt.official.stamp.feature.ranking.model.RankerUiModel
 
 @Composable
 fun RankListItem(
-    item: Any,
+    partItem: PartRankModel? = null,
+    rankerItem: RankerUiModel? = null,
     isMyRanking: Boolean = false,
     onClickPart: (PartRankModel) -> Unit = {},
     onClickUser: (RankerUiModel) -> Unit = {}
@@ -79,20 +80,41 @@ fun RankListItem(
         )
     }
 
-    val isPartRankItem = item is PartRankModel
-    val rank = if (isPartRankItem) (item as PartRankModel).rank else (item as RankerUiModel).rank
-    val name = if (isPartRankItem) (item as PartRankModel).part else (item as RankerUiModel).nickname
-    val description = if (isPartRankItem) null else (item as RankerUiModel).getDescription()
-    val score = if (isPartRankItem) (item as PartRankModel).point else (item as RankerUiModel).score
+    val isPartRankItem = partItem != null
+
+
+    var ranking: Int = -1
+    var newRank = -1
+    var name: String = ""
+    var description: String? = ""
+    var scorePoint: Int = -1
+
+    if (partItem != null) {
+        with(partItem) {
+            ranking = rank
+            newRank = -1
+            name = part
+            description = null
+            scorePoint = point
+        }
+    } else if (rankerItem != null) {
+        with(rankerItem) {
+            ranking = rank
+            newRank = rank
+            name = nickname
+            description = getDescription()
+            scorePoint = score
+        }
+    }
 
     Row(
         modifier = backgroundModifier
             .fillMaxWidth()
             .noRippleClickable {
-                if (isPartRankItem) {
-                    onClickPart(item as PartRankModel)
-                } else {
-                    onClickUser(item as RankerUiModel)
+                if (partItem != null) {
+                    onClickPart(partItem)
+                } else if (rankerItem != null) {
+                    onClickUser(rankerItem)
                 }
             }
             .padding(itemPadding),
@@ -104,7 +126,7 @@ fun RankListItem(
         ) {
             RankNumber(
                 modifier = Modifier.align(Alignment.Center),
-                rank = rank,
+                rank = ranking,
                 isPartRankNumber = isPartRankItem,
                 isMyRankNumber = isMyRanking
             )
@@ -124,8 +146,8 @@ fun RankListItem(
         ) {
             RankScore(
                 modifier = Modifier.align(Alignment.CenterEnd),
-                rank = if (isPartRankItem) -1 else (item as RankerUiModel).rank,
-                score = score,
+                rank = newRank,
+                score = scorePoint,
                 isMyRankScore = isMyRanking
             )
         }
@@ -162,33 +184,33 @@ fun PreviewRankListItem() {
     SoptTheme {
         Column(Modifier.padding(horizontal = 16.dp)) {
             RankListItem(
-                item = RankerUiModel(
+                rankerItem = RankerUiModel(
                     rank = 4,
                     nickname = "일이삼사오육칠팔구십일이삼사오육칠팔구십",
                     description = "일이삼사오육칠팔구십일이삼사오육칠팔구십",
                     score = 300
                 ),
-                true
+                isMyRanking = true
             )
             Spacer(modifier = Modifier.size(10.dp))
             RankListItem(
-                item = RankerUiModel(
+                rankerItem = RankerUiModel(
                     rank = 10,
                     nickname = "일이삼사오육칠팔구십일이삼사오육칠팔구십",
                     description = "일이삼사오육칠팔구십일이삼사오육칠팔구십",
                     score = 340
                 ),
-                false
+                isMyRanking = false
             )
             Spacer(modifier = Modifier.size(10.dp))
             RankListItem(
-                item = RankerUiModel(
+                rankerItem = RankerUiModel(
                     rank = 140,
                     nickname = "일이삼사오육칠팔구십일이삼사오육칠팔구십",
                     description = "일이삼사오육칠팔구십일이삼사오육칠팔구십",
                     score = 945
                 ),
-                false
+                isMyRanking = false
             )
         }
     }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankListItem.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankListItem.kt
@@ -40,21 +40,26 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.official.stamp.designsystem.component.util.noRippleClickable
 import org.sopt.official.stamp.designsystem.style.SoptTheme
+import org.sopt.official.stamp.feature.ranking.model.PartRankModel
 import org.sopt.official.stamp.feature.ranking.model.RankerUiModel
 
 @Composable
-fun RankListItem(item: RankerUiModel, isMyRanking: Boolean = false, onClickUser: (RankerUiModel) -> Unit = {}) {
+fun RankListItem(
+    item: Any,
+    isMyRanking: Boolean = false,
+    onClickPart: (PartRankModel) -> Unit = {},
+    onClickUser: (RankerUiModel) -> Unit = {}
+) {
     val itemPadding = PaddingValues(
-        top = 19.dp,
-        bottom = 16.dp,
-        start = 14.dp,
-        end = 14.dp
+        top = 12.dp,
+        bottom = 11.dp,
+        start = 16.dp,
+        end = 16.dp
     )
     val backgroundModifier = if (isMyRanking) {
         Modifier
@@ -73,10 +78,23 @@ fun RankListItem(item: RankerUiModel, isMyRanking: Boolean = false, onClickUser:
             shape = RoundedCornerShape(8.dp)
         )
     }
+
+    val isPartRankItem = item is PartRankModel
+    val rank = if (isPartRankItem) (item as PartRankModel).rank else (item as RankerUiModel).rank
+    val name = if (isPartRankItem) (item as PartRankModel).part else (item as RankerUiModel).nickname
+    val description = if (isPartRankItem) null else (item as RankerUiModel).getDescription()
+    val score = if (isPartRankItem) (item as PartRankModel).point else (item as RankerUiModel).score
+
     Row(
         modifier = backgroundModifier
             .fillMaxWidth()
-            .noRippleClickable { onClickUser(item) }
+            .noRippleClickable {
+                if (isPartRankItem) {
+                    onClickPart(item as PartRankModel)
+                } else {
+                    onClickUser(item as RankerUiModel)
+                }
+            }
             .padding(itemPadding),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically
@@ -86,7 +104,8 @@ fun RankListItem(item: RankerUiModel, isMyRanking: Boolean = false, onClickUser:
         ) {
             RankNumber(
                 modifier = Modifier.align(Alignment.Center),
-                rank = item.rank,
+                rank = rank,
+                isPartRankNumber = isPartRankItem,
                 isMyRankNumber = isMyRanking
             )
         }
@@ -95,18 +114,18 @@ fun RankListItem(item: RankerUiModel, isMyRanking: Boolean = false, onClickUser:
             modifier = Modifier.weight(0.53f)
         ) {
             RankerInformation(
-                user = item.nickname,
-                description = item.getDescription()
+                user = name,
+                description = description
             )
         }
         Spacer(modifier = Modifier.weight(0.04f))
         Box(
-            modifier = Modifier.weight(0.2f)
+            modifier = Modifier.weight(0.4f)
         ) {
             RankScore(
                 modifier = Modifier.align(Alignment.CenterEnd),
-                rank = item.rank,
-                score = item.score,
+                rank = if (isPartRankItem) -1 else (item as RankerUiModel).rank,
+                score = score,
                 isMyRankScore = isMyRanking
             )
         }
@@ -114,24 +133,26 @@ fun RankListItem(item: RankerUiModel, isMyRanking: Boolean = false, onClickUser:
 }
 
 @Composable
-fun RankerInformation(modifier: Modifier = Modifier, user: String, description: String) {
+fun RankerInformation(modifier: Modifier = Modifier, user: String, description: String? = null) {
     Column(modifier) {
         Text(
             modifier = Modifier.fillMaxWidth(),
             text = user,
             style = SoptTheme.typography.h3,
-            color = Color.Black,
+            color = SoptTheme.colors.onSurface80,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
-        Text(
-            modifier = Modifier.fillMaxWidth(),
-            text = description,
-            style = SoptTheme.typography.caption1,
-            color = SoptTheme.colors.onSurface70,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
+        if (description != null) {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = description,
+                style = SoptTheme.typography.caption1,
+                color = SoptTheme.colors.onSurface70,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
     }
 }
 

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankNumber.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankNumber.kt
@@ -36,14 +36,18 @@ import org.sopt.official.stamp.designsystem.style.MontserratBold
 import org.sopt.official.stamp.designsystem.style.SoptTheme
 
 @Composable
-fun RankNumber(modifier: Modifier = Modifier, rank: Int, isMyRankNumber: Boolean = false) {
+fun RankNumber(modifier: Modifier = Modifier, rank: Int, isMyRankNumber: Boolean = false, isPartRankNumber: Boolean = false) {
     val defaultRankSymbols = "-"
     Text(
         text = if (rank <= 0) defaultRankSymbols else "$rank",
         fontFamily = MontserratBold,
         fontSize = 30.sp,
         fontWeight = FontWeight.Bold,
-        color = if (isMyRankNumber) SoptTheme.colors.purple300 else getRankTextColor(rank),
+        color = when {
+            isMyRankNumber -> SoptTheme.colors.purple300
+            isMyRankNumber -> SoptTheme.colors.onSurface80
+            else -> getRankTextColor(rank)
+        },
         modifier = modifier,
         textAlign = TextAlign.Center
     )

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankingBar.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankingBar.kt
@@ -1,0 +1,26 @@
+package org.sopt.official.stamp.feature.ranking
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RankingBar(width: Dp, height: Dp, rank: Int, content: @Composable () -> Unit = {}) {
+    Box(
+        modifier = Modifier
+            .size(width, height)
+            .background(
+                color = getRankBackgroundColor(rank),
+                shape = RoundedCornerShape(8.dp)
+            ),
+        contentAlignment = Alignment.TopCenter
+    ) {
+        content()
+    }
+}

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankingBar.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/RankingBar.kt
@@ -2,19 +2,16 @@ package org.sopt.official.stamp.feature.ranking
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun RankingBar(width: Dp, height: Dp, rank: Int, content: @Composable () -> Unit = {}) {
+fun RankingBar(modifier: Modifier = Modifier, rank: Int, content: @Composable () -> Unit = {}) {
     Box(
-        modifier = Modifier
-            .size(width, height)
+        modifier = modifier
             .background(
                 color = getRankBackgroundColor(rank),
                 shape = RoundedCornerShape(8.dp)

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/TopRankerItem.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/TopRankerItem.kt
@@ -60,7 +60,7 @@ fun TopRankerItem(ranker: RankerUiModel, height: Dp, onClick: (RankerUiModel) ->
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         TopRankBarOfRankText(rank = ranker.rank)
-        RankingBar(90.dp, height, ranker.rank) {
+        RankingBar(modifier = Modifier.size(width = 90.dp, height = height), ranker.rank) {
             RankScore(
                 modifier = Modifier
                     .padding(top = 8.dp),

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/TopRankerItem.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/TopRankerItem.kt
@@ -60,7 +60,14 @@ fun TopRankerItem(ranker: RankerUiModel, height: Dp, onClick: (RankerUiModel) ->
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         TopRankBarOfRankText(rank = ranker.rank)
-        TopRankBarOfGraph(rank = ranker.rank, score = ranker.score, height = height)
+        RankingBar(90.dp, height, ranker.rank) {
+            RankScore(
+                modifier = Modifier
+                    .padding(top = 8.dp),
+                rank = ranker.rank,
+                score = ranker.score
+            )
+        }
         Spacer(modifier = Modifier.size(10.dp))
         TopRankBarOfUserName(
             rank = ranker.rank,
@@ -88,26 +95,6 @@ fun TopRankBarOfRankText(rank: Int) {
     } else {
         RankNumber(rank = rank)
         Spacer(modifier = Modifier.size(10.dp))
-    }
-}
-
-@Composable
-fun TopRankBarOfGraph(rank: Int, score: Int, height: Dp) {
-    Box(
-        modifier = Modifier
-            .size(90.dp, height)
-            .background(
-                color = getRankBackgroundColor(rank),
-                shape = RoundedCornerShape(8.dp)
-            )
-    ) {
-        RankScore(
-            modifier = Modifier
-                .align(Alignment.TopCenter)
-                .padding(top = 8.dp),
-            rank = rank,
-            score = score
-        )
     }
 }
 

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/model/PartRankModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/model/PartRankModel.kt
@@ -1,0 +1,7 @@
+package org.sopt.official.stamp.feature.ranking.model
+
+data class PartRankModel(
+    val rank: Int,
+    val part: String,
+    val point: Int
+)

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -39,7 +38,6 @@ import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.immutableListOf
 import kotlinx.collections.immutable.persistentListOf
 import org.sopt.official.analytics.EventType
 import org.sopt.official.stamp.LocalTracker
@@ -161,34 +159,11 @@ fun PartRankingBarList(rankList: List<PartRankModel>) {
         verticalAlignment = Alignment.Bottom
     ) {
         items(rankList) { part ->
-            PartRankingBar(part)
+            RankingBar(
+                modifier = Modifier.size(width = 50.dp, height = getRankHeight(part.rank)),
+                rank = part.rank
+            )
         }
-    }
-}
-
-@Composable
-fun PartRankingBar(part: PartRankModel, width: Dp = 50.dp) {
-    val newRank = if (part.point != 0) {
-        part.rank
-    } else {
-        0
-    }
-
-    Column(
-        verticalArrangement = Arrangement.Bottom,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        if (part.rank < 4 && part.point != 0) {
-            TopRankBarOfRankText(rank = part.rank)
-        }
-        RankingBar(modifier = Modifier.size(width = 50.dp, height = getRankHeight(newRank)), rank = newRank)
-        Spacer(modifier = Modifier.size(8.dp))
-        Text(
-            text = part.part,
-            maxLines = 1,
-            style = SoptTheme.typography.sub3,
-            color = SoptTheme.colors.onSurface80
-        )
     }
 }
 

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
@@ -83,8 +83,8 @@ fun PartRankingScreen(
             is PartRankingState.Success -> PartRankingScreen(
                 partRankList = (state as PartRankingState.Success).partRankList,
                 refreshing = partRankingViewModel.isRefreshing,
-                onRefresh = { partRankingViewModel.onRefresh() },
-                onClickBack = { resultNavigator.navigateBack() },
+                onRefresh = partRankingViewModel::onRefresh,
+                onClickBack = resultNavigator::navigateBack,
                 onClickPart = {
                     navigator.navigate(RankingScreenDestination(it))
                 }
@@ -184,7 +184,7 @@ fun PartRankingBar(part: PartRankModel, width: Dp = 50.dp) {
             text = part.part,
             maxLines = 1,
             style = SoptTheme.typography.sub3,
-            color = Gray800
+            color = SoptTheme.colors.onSurface80
         )
     }
 }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
@@ -45,7 +45,6 @@ import org.sopt.official.stamp.config.navigation.MissionNavGraph
 import org.sopt.official.stamp.designsystem.component.dialog.SingleOptionDialog
 import org.sopt.official.stamp.designsystem.component.layout.LoadingScreen
 import org.sopt.official.stamp.designsystem.component.util.noRippleClickable
-import org.sopt.official.stamp.designsystem.style.Gray500
 import org.sopt.official.stamp.designsystem.style.Gray800
 import org.sopt.official.stamp.designsystem.style.MontserratBold
 import org.sopt.official.stamp.designsystem.style.SoptTheme
@@ -159,11 +158,37 @@ fun PartRankingBarList(rankList: List<PartRankModel>) {
         verticalAlignment = Alignment.Bottom
     ) {
         items(rankList) { part ->
-            RankingBar(
-                modifier = Modifier.size(width = 50.dp, height = getRankHeight(part.rank)),
-                rank = part.rank
-            )
+            PartRankingBar(part = part, modifier = Modifier.size(width = 50.dp, height = getRankHeight(part.rank)))
         }
+    }
+}
+
+@Composable
+fun PartRankingBar(part: PartRankModel, modifier: Modifier) {
+    val newRank = if (part.point != 0) {
+        part.rank
+    } else {
+        0
+    }
+
+    Column(
+        verticalArrangement = Arrangement.Bottom,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        if (part.rank < 4 && part.point != 0) {
+            TopRankBarOfRankText(rank = part.rank)
+        }
+        RankingBar(
+            modifier = modifier,
+            rank = newRank
+        )
+        Spacer(modifier = Modifier.size(8.dp))
+        Text(
+            text = part.part,
+            maxLines = 1,
+            style = SoptTheme.typography.sub3,
+            color = SoptTheme.colors.onSurface80
+        )
     }
 }
 
@@ -196,7 +221,7 @@ fun PartRankListItem(item: PartRankModel, onClickPart: () -> Unit = {}) {
                 fontFamily = MontserratBold,
                 fontSize = 30.sp,
                 fontWeight = FontWeight.Bold,
-                color = Gray500,
+                color = SoptTheme.colors.onSurface50,
                 modifier = Modifier.align(Alignment.Center),
                 textAlign = TextAlign.Center
             )

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
@@ -125,7 +125,7 @@ fun PartRankingScreen(
                 }
                 items(partRankList.sortedBy { it.rank }) { item ->
                     RankListItem(
-                        item = item,
+                        partItem = item,
                         onClickPart = {
                             onClickPart(item.part)
                         }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
@@ -67,7 +67,8 @@ fun PartRankingScreen(
     val tracker = LocalTracker.current
     LaunchedEffect(true) {
         tracker.track(
-            EventType.VIEW, "partranking"
+            EventType.VIEW,
+            "partranking"
         )
         // TODO: Data fetch
     }
@@ -91,7 +92,6 @@ fun PartRankingScreen(
         }
     }
 }
-
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
@@ -1,11 +1,9 @@
 package org.sopt.official.stamp.feature.ranking.part
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -14,7 +12,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
@@ -27,12 +24,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
@@ -44,12 +37,9 @@ import org.sopt.official.stamp.LocalTracker
 import org.sopt.official.stamp.config.navigation.MissionNavGraph
 import org.sopt.official.stamp.designsystem.component.dialog.SingleOptionDialog
 import org.sopt.official.stamp.designsystem.component.layout.LoadingScreen
-import org.sopt.official.stamp.designsystem.component.util.noRippleClickable
-import org.sopt.official.stamp.designsystem.style.Gray800
-import org.sopt.official.stamp.designsystem.style.MontserratBold
 import org.sopt.official.stamp.designsystem.style.SoptTheme
 import org.sopt.official.stamp.feature.destinations.RankingScreenDestination
-import org.sopt.official.stamp.feature.ranking.RankScore
+import org.sopt.official.stamp.feature.ranking.RankListItem
 import org.sopt.official.stamp.feature.ranking.RankingBar
 import org.sopt.official.stamp.feature.ranking.TopRankBarOfRankText
 import org.sopt.official.stamp.feature.ranking.model.PartRankModel
@@ -133,8 +123,8 @@ fun PartRankingScreen(
                 item {
                     PartRankingBarList(partRankList)
                 }
-                items(partRankList.sortedBy { it.rank }) { item -> // 리스트를 받으면 넣을 예정
-                    PartRankListItem(
+                items(partRankList.sortedBy { it.rank }) { item ->
+                    RankListItem(
                         item = item,
                         onClickPart = {
                             onClickPart(item.part)
@@ -189,66 +179,6 @@ fun PartRankingBar(part: PartRankModel, modifier: Modifier) {
             style = SoptTheme.typography.sub3,
             color = SoptTheme.colors.onSurface80
         )
-    }
-}
-
-@Composable
-fun PartRankListItem(item: PartRankModel, onClickPart: () -> Unit = {}) {
-    val itemPadding = PaddingValues(
-        top = 12.dp,
-        bottom = 11.dp,
-        start = 16.dp,
-        end = 16.dp
-    )
-    val backgroundModifier = Modifier.background(
-        color = SoptTheme.colors.onSurface5,
-        shape = RoundedCornerShape(8.dp)
-    )
-
-    Row(
-        modifier = backgroundModifier
-            .fillMaxWidth()
-            .noRippleClickable { onClickPart() }
-            .padding(itemPadding),
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Box(
-            modifier = Modifier.weight(0.18f)
-        ) {
-            Text(
-                text = if (item.rank <= 0) "-" else "${item.rank}",
-                fontFamily = MontserratBold,
-                fontSize = 30.sp,
-                fontWeight = FontWeight.Bold,
-                color = SoptTheme.colors.onSurface50,
-                modifier = Modifier.align(Alignment.Center),
-                textAlign = TextAlign.Center
-            )
-        }
-        Spacer(modifier = Modifier.weight(0.05f))
-        Box(
-            modifier = Modifier.weight(0.53f)
-        ) {
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                text = item.part,
-                style = SoptTheme.typography.h3,
-                color = Gray800,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-        Spacer(modifier = Modifier.weight(0.04f))
-        Box(
-            modifier = Modifier.weight(0.4f)
-        ) {
-            RankScore(
-                modifier = Modifier.align(Alignment.CenterEnd),
-                rank = -1,
-                score = item.point,
-            )
-        }
     }
 }
 

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
@@ -44,6 +44,7 @@ import org.sopt.official.stamp.feature.ranking.rank.RankingHeader
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun PartRankingScreen(
+    partRankList: List<PartRankModel>,
     refreshing: Boolean = false,
     onRefresh: () -> Unit = {},
     onClickBack: () -> Unit = {}
@@ -83,7 +84,7 @@ fun PartRankingScreen(
                     PartRankListItem(
                         item = item,
                         onClickUser = {
-                            // 페이지 이동
+                            // 파트별 랭킹 페이지 이동 (기존 RankingScreen 활용)
                         }
                     )
                 }
@@ -94,7 +95,7 @@ fun PartRankingScreen(
 }
 
 @Composable
-fun PartRankingBarList(rankList: List<PartRankModel> = partRankList) {
+fun PartRankingBarList(rankList: List<PartRankModel>) {
     LazyRow(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(
@@ -204,43 +205,42 @@ fun getRankHeight(rank: Int) = when (rank) {
     else -> 27.dp
 }
 
-val partRankList = listOf(
-    PartRankModel(
-        3,
-        "기획",
-        500
-    ),
-    PartRankModel(
-        4,
-        "디자인",
-        400
-    ),
-    PartRankModel(
-        6,
-        "웹",
-        100
-    ),
-    PartRankModel(
-        1,
-        "아요",
-        10000
-    ),
-    PartRankModel(
-        2,
-        "안드",
-        800
-    ),
-    PartRankModel(
-        5,
-        "서버",
-        200
-    ),
-)
-
 @Preview
 @Composable
 fun PartRankingPreview() {
+    val partRankList = listOf(
+        PartRankModel(
+            3,
+            "기획",
+            500
+        ),
+        PartRankModel(
+            4,
+            "디자인",
+            400
+        ),
+        PartRankModel(
+            6,
+            "웹",
+            100
+        ),
+        PartRankModel(
+            2,
+            "아요",
+            1000
+        ),
+        PartRankModel(
+            1,
+            "안드",
+            8000
+        ),
+        PartRankModel(
+            5,
+            "서버",
+            200
+        ),
+    )
     SoptTheme {
-        PartRankingScreen()
+        PartRankingScreen(partRankList)
     }
 }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
@@ -38,6 +38,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.ramcosta.composedestinations.result.ResultBackNavigator
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.immutableListOf
+import kotlinx.collections.immutable.persistentListOf
 import org.sopt.official.analytics.EventType
 import org.sopt.official.stamp.LocalTracker
 import org.sopt.official.stamp.config.navigation.MissionNavGraph
@@ -96,7 +99,7 @@ fun PartRankingScreen(
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun PartRankingScreen(
-    partRankList: List<PartRankModel>,
+    partRankList: ImmutableList<PartRankModel>,
     refreshing: Boolean = false,
     onRefresh: () -> Unit = {},
     onClickBack: () -> Unit = {},
@@ -261,7 +264,7 @@ fun getRankHeight(rank: Int) = when (rank) {
 @Preview
 @Composable
 fun PartRankingPreview() {
-    val partRankList = listOf(
+    val partRankList = persistentListOf(
         PartRankModel(
             3,
             "기획",
@@ -291,7 +294,7 @@ fun PartRankingPreview() {
             5,
             "서버",
             200
-        ),
+        )
     )
     SoptTheme {
         PartRankingScreen(partRankList)

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
@@ -1,0 +1,261 @@
+package org.sopt.official.stamp.feature.ranking.part
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.sopt.official.stamp.designsystem.component.util.noRippleClickable
+import org.sopt.official.stamp.designsystem.style.Gray500
+import org.sopt.official.stamp.designsystem.style.Gray800
+import org.sopt.official.stamp.designsystem.style.MontserratBold
+import org.sopt.official.stamp.designsystem.style.SoptTheme
+import org.sopt.official.stamp.feature.ranking.RankScore
+import org.sopt.official.stamp.feature.ranking.TopRankBarOfRankText
+import org.sopt.official.stamp.feature.ranking.getRankBackgroundColor
+import org.sopt.official.stamp.feature.ranking.model.PartRankModel
+import org.sopt.official.stamp.feature.ranking.rank.RankingHeader
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun PartRankingScreen(
+    refreshing: Boolean = false,
+    onRefresh: () -> Unit = {},
+    onClickBack: () -> Unit = {}
+) {
+    val refreshingState = rememberPullRefreshState(
+        refreshing = refreshing,
+        onRefresh = onRefresh
+    )
+    val listState = rememberLazyListState()
+
+    Scaffold(
+        topBar = {
+            RankingHeader(
+                title = "파트별 랭킹",
+                onClickBack = { onClickBack() }
+            )
+        }
+    ) { paddingValues ->
+        val defaultPadding = PaddingValues(
+            top = paddingValues.calculateTopPadding(),
+            bottom = paddingValues.calculateBottomPadding(),
+            start = 16.dp,
+            end = 16.dp
+        )
+        Box(
+            modifier = Modifier.pullRefresh(refreshingState)
+        ) {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.padding(defaultPadding),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                item {
+                    PartRankingBarList(partRankList)
+                }
+                items(partRankList.sortedBy { it.rank }) { item -> // 리스트를 받으면 넣을 예정
+                    PartRankListItem(
+                        item = item,
+                        onClickUser = {
+                            // 페이지 이동
+                        }
+                    )
+                }
+            }
+            PullRefreshIndicator(refreshing, refreshingState, Modifier.align(Alignment.TopCenter))
+        }
+    }
+}
+
+@Composable
+fun PartRankingBarList(rankList: List<PartRankModel> = partRankList) {
+    LazyRow(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(
+            8.dp,
+            Alignment.CenterHorizontally
+        ),
+        verticalAlignment = Alignment.Bottom
+    ) {
+        items(rankList) { part ->
+            PartRankingBar(part)
+        }
+    }
+}
+
+@Composable
+fun PartRankingBar(part: PartRankModel) {
+    val newRank = if (part.point != 0) {
+        part.rank
+    } else {
+        0
+    }
+
+    Column(
+        verticalArrangement = Arrangement.Bottom,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        if (part.rank < 4 && part.point != 0) {
+            TopRankBarOfRankText(rank = part.rank)
+        }
+        RankingBar(width = 50.dp, height = getRankHeight(newRank), rank = newRank)
+        Spacer(modifier = Modifier.size(8.dp))
+        Text(
+            text = part.part,
+            maxLines = 1,
+            style = SoptTheme.typography.sub3,
+            color = Gray800
+        )
+    }
+}
+
+@Composable
+fun RankingBar(width: Dp, height: Dp, rank: Int, content: () -> Unit = {}) {
+    Box(
+        modifier = Modifier
+            .size(width, height)
+            .background(
+                color = getRankBackgroundColor(rank),
+                shape = RoundedCornerShape(8.dp)
+            )
+    ) {
+        content()
+    }
+}
+
+@Composable
+fun PartRankListItem(item: PartRankModel, onClickUser: () -> Unit = {}) {
+    val itemPadding = PaddingValues(
+        top = 12.dp,
+        bottom = 11.dp,
+        start = 16.dp,
+        end = 16.dp
+    )
+    val backgroundModifier = Modifier.background(
+        color = SoptTheme.colors.onSurface5,
+        shape = RoundedCornerShape(8.dp)
+    )
+
+    Row(
+        modifier = backgroundModifier
+            .fillMaxWidth()
+            .noRippleClickable { onClickUser() }
+            .padding(itemPadding),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier.weight(0.18f)
+        ) {
+            Text(
+                text = if (item.rank <= 0) "-" else "${item.rank}",
+                fontFamily = MontserratBold,
+                fontSize = 30.sp,
+                fontWeight = FontWeight.Bold,
+                color = Gray500,
+                modifier = Modifier.align(Alignment.Center),
+                textAlign = TextAlign.Center
+            )
+        }
+        Spacer(modifier = Modifier.weight(0.05f))
+        Box(
+            modifier = Modifier.weight(0.53f)
+        ) {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = item.part,
+                style = SoptTheme.typography.h3,
+                color = Gray800,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        Spacer(modifier = Modifier.weight(0.04f))
+        Box(
+            modifier = Modifier.weight(0.4f)
+        ) {
+            RankScore(
+                modifier = Modifier.align(Alignment.CenterEnd),
+                rank = -1,
+                score = item.point,
+            )
+        }
+    }
+}
+
+fun getRankHeight(rank: Int) = when (rank) {
+    1 -> 163.dp
+    2 -> 135.dp
+    3 -> 108.dp
+    4 -> 81.dp
+    5 -> 54.dp
+    else -> 27.dp
+}
+
+val partRankList = listOf(
+    PartRankModel(
+        3,
+        "기획",
+        500
+    ),
+    PartRankModel(
+        4,
+        "디자인",
+        400
+    ),
+    PartRankModel(
+        6,
+        "웹",
+        100
+    ),
+    PartRankModel(
+        1,
+        "아요",
+        10000
+    ),
+    PartRankModel(
+        2,
+        "안드",
+        800
+    ),
+    PartRankModel(
+        5,
+        "서버",
+        200
+    ),
+)
+
+@Preview
+@Composable
+fun PartRankingPreview() {
+    SoptTheme {
+        PartRankingScreen()
+    }
+}

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.sopt.official.stamp.designsystem.component.util.noRippleClickable
@@ -37,8 +36,8 @@ import org.sopt.official.stamp.designsystem.style.Gray800
 import org.sopt.official.stamp.designsystem.style.MontserratBold
 import org.sopt.official.stamp.designsystem.style.SoptTheme
 import org.sopt.official.stamp.feature.ranking.RankScore
+import org.sopt.official.stamp.feature.ranking.RankingBar
 import org.sopt.official.stamp.feature.ranking.TopRankBarOfRankText
-import org.sopt.official.stamp.feature.ranking.getRankBackgroundColor
 import org.sopt.official.stamp.feature.ranking.model.PartRankModel
 import org.sopt.official.stamp.feature.ranking.rank.RankingHeader
 
@@ -133,20 +132,6 @@ fun PartRankingBar(part: PartRankModel) {
             style = SoptTheme.typography.sub3,
             color = Gray800
         )
-    }
-}
-
-@Composable
-fun RankingBar(width: Dp, height: Dp, rank: Int, content: () -> Unit = {}) {
-    Box(
-        modifier = Modifier
-            .size(width, height)
-            .background(
-                color = getRankBackgroundColor(rank),
-                shape = RoundedCornerShape(8.dp)
-            )
-    ) {
-        content()
     }
 }
 

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
@@ -38,6 +38,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.ramcosta.composedestinations.result.ResultBackNavigator
+import org.sopt.official.analytics.EventType
+import org.sopt.official.stamp.LocalTracker
 import org.sopt.official.stamp.config.navigation.MissionNavGraph
 import org.sopt.official.stamp.designsystem.component.dialog.SingleOptionDialog
 import org.sopt.official.stamp.designsystem.component.layout.LoadingScreen
@@ -46,6 +48,7 @@ import org.sopt.official.stamp.designsystem.style.Gray500
 import org.sopt.official.stamp.designsystem.style.Gray800
 import org.sopt.official.stamp.designsystem.style.MontserratBold
 import org.sopt.official.stamp.designsystem.style.SoptTheme
+import org.sopt.official.stamp.feature.destinations.RankingScreenDestination
 import org.sopt.official.stamp.feature.ranking.RankScore
 import org.sopt.official.stamp.feature.ranking.RankingBar
 import org.sopt.official.stamp.feature.ranking.TopRankBarOfRankText
@@ -61,7 +64,11 @@ fun PartRankingScreen(
     navigator: DestinationsNavigator
 ) {
     val state by partRankingViewModel.state.collectAsState()
+    val tracker = LocalTracker.current
     LaunchedEffect(true) {
+        tracker.track(
+            EventType.VIEW, "partranking"
+        )
         // TODO: Data fetch
     }
 
@@ -78,8 +85,7 @@ fun PartRankingScreen(
                 onRefresh = { partRankingViewModel.onRefresh() },
                 onClickBack = { resultNavigator.navigateBack() },
                 onClickPart = {
-                    // TODO: Navigate PartDetailRanking
-                    // arg로 --파트 or 34기 이렇게 보내주고, 그걸 랭킹에서 받아서 쓰자.
+                    navigator.navigate(RankingScreenDestination(it))
                 }
             )
         }
@@ -94,7 +100,7 @@ fun PartRankingScreen(
     refreshing: Boolean = false,
     onRefresh: () -> Unit = {},
     onClickBack: () -> Unit = {},
-    onClickPart: () -> Unit = {}
+    onClickPart: (String) -> Unit = {}
 ) {
     val refreshingState = rememberPullRefreshState(
         refreshing = refreshing,
@@ -130,7 +136,9 @@ fun PartRankingScreen(
                 items(partRankList.sortedBy { it.rank }) { item -> // 리스트를 받으면 넣을 예정
                     PartRankListItem(
                         item = item,
-                        onClickPart = onClickPart
+                        onClickPart = {
+                            onClickPart(item.part)
+                        }
                     )
                 }
             }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingScreen.kt
@@ -178,7 +178,7 @@ fun PartRankingBar(part: PartRankModel, width: Dp = 50.dp) {
         if (part.rank < 4 && part.point != 0) {
             TopRankBarOfRankText(rank = part.rank)
         }
-        RankingBar(width = 50.dp, height = getRankHeight(newRank), rank = newRank)
+        RankingBar(modifier = Modifier.size(width = 50.dp, height = getRankHeight(newRank)), rank = newRank)
         Spacer(modifier = Modifier.size(8.dp))
         Text(
             text = part.part,

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingState.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingState.kt
@@ -1,0 +1,35 @@
+/*
+ * MIT License
+ * Copyright 2023 SOPT - Shout Our Passion Together
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.sopt.official.stamp.feature.ranking.part
+
+import org.sopt.official.stamp.feature.ranking.model.PartRankModel
+
+sealed class PartRankingState {
+    data object Loading : PartRankingState()
+
+    data class Success(val partRankList: List<PartRankModel>) : PartRankingState()
+
+    data object Failure : PartRankingState()
+}

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingState.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingState.kt
@@ -24,12 +24,13 @@
  */
 package org.sopt.official.stamp.feature.ranking.part
 
+import kotlinx.collections.immutable.ImmutableList
 import org.sopt.official.stamp.feature.ranking.model.PartRankModel
 
 sealed class PartRankingState {
     data object Loading : PartRankingState()
 
-    data class Success(val partRankList: List<PartRankModel>) : PartRankingState()
+    data class Success(val partRankList: ImmutableList<PartRankModel>) : PartRankingState()
 
     data object Failure : PartRankingState()
 }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingViewModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingViewModel.kt
@@ -6,12 +6,12 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.sopt.official.stamp.feature.ranking.model.PartRankModel
-import javax.inject.Inject
 
 @HiltViewModel
 class PartRankingViewModel @Inject constructor() : ViewModel() {

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingViewModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingViewModel.kt
@@ -1,0 +1,32 @@
+package org.sopt.official.stamp.feature.ranking.part
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.sopt.official.stamp.feature.ranking.model.PartRankModel
+import javax.inject.Inject
+
+@HiltViewModel
+class PartRankingViewModel @Inject constructor() : ViewModel() {
+    private val _state: MutableStateFlow<PartRankingState> = MutableStateFlow(PartRankingState.Loading)
+    val state: StateFlow<PartRankingState> = _state.asStateFlow()
+    var isRefreshing by mutableStateOf(false)
+
+    fun onRefresh() {
+        viewModelScope.launch {
+            isRefreshing = true
+            // TODO: Fetch Data
+        }
+    }
+
+    private fun onSuccessStateChange(ranking: List<PartRankModel>) {
+        _state.value = PartRankingState.Success(ranking)
+    }
+}

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingViewModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingViewModel.kt
@@ -6,13 +6,13 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.sopt.official.stamp.feature.ranking.model.PartRankModel
-import javax.inject.Inject
 
 @HiltViewModel
 class PartRankingViewModel @Inject constructor() : ViewModel() {

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingViewModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -26,7 +27,7 @@ class PartRankingViewModel @Inject constructor() : ViewModel() {
         }
     }
 
-    private fun onSuccessStateChange(ranking: List<PartRankModel>) {
+    private fun onSuccessStateChange(ranking: ImmutableList<PartRankModel>) {
         _state.value = PartRankingState.Success(ranking)
     }
 }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingViewModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/part/PartRankingViewModel.kt
@@ -7,12 +7,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
-import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.sopt.official.stamp.feature.ranking.model.PartRankModel
+import javax.inject.Inject
 
 @HiltViewModel
 class PartRankingViewModel @Inject constructor() : ViewModel() {

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
@@ -131,12 +131,13 @@ fun RankingScreen(
     val tracker = LocalTracker.current
     LaunchedEffect(true) {
         tracker.track(
-            EventType.VIEW, if (isCurrent) "nowranking" else "partranking")
+            EventType.VIEW, if (isCurrent) "nowranking" else "partdetailranking"
+        )
     }
     Scaffold(
         topBar = {
             RankingHeader(
-                title = type + " 랭킹",
+                title = if (isCurrent) "$type 랭킹" else "$type 파트 랭킹",
                 onClickBack = { onClickBack() }
             )
         },

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
@@ -138,7 +138,7 @@ fun RankingScreen(
     Scaffold(
         topBar = {
             RankingHeader(
-                title = if (isCurrent) "$type 랭킹" else type +"파트 랭킹",
+                title = if (isCurrent) "$type 랭킹" else type + "파트 랭킹",
                 onClickBack = { onClickBack() }
             )
         },

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
@@ -78,11 +78,12 @@ import org.sopt.official.stamp.util.toPx
 @Destination("ranking")
 @Composable
 fun RankingScreen(
-    isCurrent: Boolean,
+    type: String,
     rankingViewModel: RankingViewModel = hiltViewModel(),
     resultNavigator: ResultBackNavigator<Boolean>,
     navigator: DestinationsNavigator
 ) {
+    val isCurrent = type == "34기"
     val state by rankingViewModel.state.collectAsState()
     LaunchedEffect(true) {
         rankingViewModel.fetchRanking(isCurrent)
@@ -96,6 +97,7 @@ fun RankingScreen(
 
             is RankingState.Success -> RankingScreen(
                 isCurrent = isCurrent,
+                type = type,
                 refreshing = rankingViewModel.isRefreshing,
                 onRefresh = { rankingViewModel.onRefresh(isCurrent) },
                 rankingListUiModel = (state as RankingState.Success).uiModel,
@@ -111,6 +113,7 @@ fun RankingScreen(
 @Composable
 fun RankingScreen(
     isCurrent: Boolean,
+    type: String,
     refreshing: Boolean = false,
     onRefresh: () -> Unit = {},
     rankingListUiModel: RankingListUiModel,
@@ -127,12 +130,13 @@ fun RankingScreen(
     val scrollOffsetPx = (-257).dp.toPx()
     val tracker = LocalTracker.current
     LaunchedEffect(true) {
-        tracker.track(EventType.VIEW, if (isCurrent) "nowranking" else "allranking")
+        tracker.track(
+            EventType.VIEW, if (isCurrent) "nowranking" else "partranking")
     }
     Scaffold(
         topBar = {
             RankingHeader(
-                title = if (isCurrent) "34기 랭킹" else "전체 랭킹",
+                title = type + " 랭킹",
                 onClickBack = { onClickBack() }
             )
         },
@@ -225,7 +229,8 @@ fun PreviewRankingScreen() {
     }
     SoptTheme {
         RankingScreen(
-            isCurrent = false,
+            isCurrent = true,
+            type = "34기",
             rankingListUiModel = RankingListUiModel(previewRanking),
             nickname = "",
         )

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
@@ -131,7 +131,8 @@ fun RankingScreen(
     val tracker = LocalTracker.current
     LaunchedEffect(true) {
         tracker.track(
-            EventType.VIEW, if (isCurrent) "nowranking" else "partdetailranking"
+            EventType.VIEW,
+            if (isCurrent) "nowranking" else "partdetailranking"
         )
     }
     Scaffold(

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
@@ -102,7 +102,7 @@ fun RankingScreen(
                 onRefresh = { rankingViewModel.onRefresh(isCurrent) },
                 rankingListUiModel = (state as RankingState.Success).uiModel,
                 nickname = rankingViewModel.nickname,
-                onClickBack = { resultNavigator.navigateBack() },
+                onClickBack = resultNavigator::navigateBack,
                 onClickUser = { ranker -> navigator.navigate(UserMissionListScreenDestination(ranker)) }
             )
         }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
@@ -22,7 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.sopt.official.stamp.feature.ranking
+package org.sopt.official.stamp.feature.ranking.rank
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -66,6 +66,8 @@ import org.sopt.official.stamp.designsystem.component.layout.LoadingScreen
 import org.sopt.official.stamp.designsystem.component.topappbar.SoptTopAppBar
 import org.sopt.official.stamp.designsystem.style.SoptTheme
 import org.sopt.official.stamp.feature.destinations.UserMissionListScreenDestination
+import org.sopt.official.stamp.feature.ranking.RankListItem
+import org.sopt.official.stamp.feature.ranking.TopRankerList
 import org.sopt.official.stamp.feature.ranking.model.RankerNavArg
 import org.sopt.official.stamp.feature.ranking.model.RankerUiModel
 import org.sopt.official.stamp.feature.ranking.model.RankingListUiModel

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
@@ -138,7 +138,7 @@ fun RankingScreen(
     Scaffold(
         topBar = {
             RankingHeader(
-                title = if (isCurrent) "$type 랭킹" else "$type 파트 랭킹",
+                title = if (isCurrent) "$type 랭킹" else type +"파트 랭킹",
                 onClickBack = { onClickBack() }
             )
         },

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingScreen.kt
@@ -184,7 +184,7 @@ fun RankingScreen(
                 }
                 items(rankingListUiModel.otherRankingList) { item ->
                     RankListItem(
-                        item = item,
+                        rankerItem = item,
                         isMyRanking = item.nickname == nickname,
                         onClickUser = { ranker ->
                             if (nickname != ranker.nickname) onClickUser(ranker.toArgs())

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingState.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingState.kt
@@ -22,7 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.sopt.official.stamp.feature.ranking
+package org.sopt.official.stamp.feature.ranking.rank
 
 import org.sopt.official.stamp.feature.ranking.model.RankingListUiModel
 

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingViewModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/ranking/rank/RankingViewModel.kt
@@ -22,7 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.sopt.official.stamp.feature.ranking
+package org.sopt.official.stamp.feature.ranking.rank
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ kotlinx-serialization-json = "1.6.3"
 kotlinx-serialization-converter = "1.0.0"
 kotlinx-coroutines = "1.8.0"
 kotlinx-datetime = "0.5.0"
+kotlinx-collections-immutable = "0.3.7"
 javax-inject = "1"
 corektx = "1.12.0"
 appcompat = "1.6.1"
@@ -73,6 +74,7 @@ kotlin-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-s
 kotlin-coroutines-google-play = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines" }
 kotlin-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlin-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
+kotlin-collections-immutable = {group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable"}
 javax-inject = { group = "javax.inject", name = "javax.inject", version.ref = "javax-inject" }
 
 activity = { module = "androidx.activity:activity-ktx", version.ref = "activity" }


### PR DESCRIPTION
closed #637 
## What is this issue?
- [x] 파트별 랭킹 UI 구현
- [x] 페이지 이동 연결 

https://github.com/sopt-makers/sopt-android/assets/52882799/73e0b257-ff74-4366-b432-349bf0c2f4f5


## To Reviewer
통짜 PR 죄송합니다... 하다가 잘 되길래 신나서 많이 해버렸어요...
api연결 제외한 부분 전부 구현했습니다!
파트별 랭킹부분은 현재 api 연결이 안되어있어 더미데이터를 넣어서 영상 찍은 후 수정했습니다.
