### PR TITLE
[feature/apply-lifecycle-service] Service에 Lifecycle 적용하기

### DIFF
--- a/app/src/main/java/org/sopt/official/config/messaging/ServiceLifecycleDispatcher.kt
+++ b/app/src/main/java/org/sopt/official/config/messaging/ServiceLifecycleDispatcher.kt
@@ -1,0 +1,76 @@
+package org.sopt.official.config.messaging
+
+import android.os.Handler
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+
+class ServiceLifecycleDispatcher(provider: LifecycleOwner) {
+    private val registry: LifecycleRegistry = LifecycleRegistry(provider)
+    private val handler: Handler
+    private var lastDispatchRunnable: DispatchRunnable? = null
+
+    init {
+        @Suppress("DEPRECATION")
+        handler = Handler()
+    }
+
+    private fun postDispatchRunnable(event: Lifecycle.Event) {
+        lastDispatchRunnable?.run()
+        lastDispatchRunnable = DispatchRunnable(registry, event)
+        handler.postAtFrontOfQueue(lastDispatchRunnable!!)
+    }
+
+    /**
+     * Must be a first call in [Service.onCreate] method, even before super.onCreate call.
+     */
+    fun onServicePreSuperOnCreate() {
+        postDispatchRunnable(Lifecycle.Event.ON_CREATE)
+    }
+
+    /**
+     * Must be a first call in [Service.onBind] method, even before super.onBind
+     * call.
+     */
+    fun onServicePreSuperOnBind() {
+        postDispatchRunnable(Lifecycle.Event.ON_START)
+    }
+
+    /**
+     * Must be a first call in [Service.onStart] or
+     * [Service.onStartCommand] methods, even before
+     * a corresponding super call.
+     */
+    fun onServicePreSuperOnStart() {
+        postDispatchRunnable(Lifecycle.Event.ON_START)
+    }
+
+    /**
+     * Must be a first call in [Service.onDestroy] method, even before super.OnDestroy
+     * call.
+     */
+    fun onServicePreSuperOnDestroy() {
+        postDispatchRunnable(Lifecycle.Event.ON_STOP)
+        postDispatchRunnable(Lifecycle.Event.ON_DESTROY)
+    }
+
+    /**
+     * [Lifecycle] for the given [LifecycleOwner]
+     */
+    val lifecycle: Lifecycle
+        get() = registry
+
+    internal class DispatchRunnable(
+        private val registry: LifecycleRegistry,
+        val event: Lifecycle.Event
+    ) : Runnable {
+        private var wasExecuted = false
+
+        override fun run() {
+            if (!wasExecuted) {
+                registry.handleLifecycleEvent(event)
+                wasExecuted = true
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/sopt/official/config/messaging/SoptFirebaseMessagingService.kt
+++ b/app/src/main/java/org/sopt/official/config/messaging/SoptFirebaseMessagingService.kt
@@ -37,13 +37,13 @@ import androidx.lifecycle.lifecycleScope
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlinx.coroutines.launch
 import org.sopt.official.R
 import org.sopt.official.auth.model.UserStatus
 import org.sopt.official.domain.usecase.notification.RegisterPushTokenUseCase
 import org.sopt.official.feature.notification.SchemeActivity
 import org.sopt.official.network.persistence.SoptDataStore
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class SoptFirebaseMessagingService : FirebaseMessagingService(), LifecycleOwner {

--- a/app/src/main/java/org/sopt/official/config/messaging/SoptFirebaseMessagingService.kt
+++ b/app/src/main/java/org/sopt/official/config/messaging/SoptFirebaseMessagingService.kt
@@ -27,24 +27,26 @@ package org.sopt.official.config.messaging
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.os.Build
+import androidx.annotation.CallSuper
 import androidx.core.app.NotificationCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.sopt.official.R
 import org.sopt.official.auth.model.UserStatus
 import org.sopt.official.domain.usecase.notification.RegisterPushTokenUseCase
 import org.sopt.official.feature.notification.SchemeActivity
 import org.sopt.official.network.persistence.SoptDataStore
+import javax.inject.Inject
 
 @AndroidEntryPoint
-class SoptFirebaseMessagingService : FirebaseMessagingService() {
+class SoptFirebaseMessagingService : FirebaseMessagingService(), LifecycleOwner {
 
     @Inject
     lateinit var dataStore: SoptDataStore
@@ -52,12 +54,28 @@ class SoptFirebaseMessagingService : FirebaseMessagingService() {
     @Inject
     lateinit var registerPushTokenUseCase: RegisterPushTokenUseCase
 
-    private val job = SupervisorJob()
-    private val scope = CoroutineScope(Dispatchers.IO + job)
+    private val dispatcher = ServiceLifecycleDispatcher(this)
+
+    override val lifecycle: Lifecycle
+        get() = dispatcher.lifecycle
+
+    @CallSuper
+    override fun onCreate() {
+        dispatcher.onServicePreSuperOnCreate()
+        super.onCreate()
+    }
+
+    @Deprecated("Deprecated in Java")
+    @Suppress("DEPRECATION")
+    @CallSuper
+    override fun onStart(intent: Intent?, startId: Int) {
+        dispatcher.onServicePreSuperOnStart()
+        super.onStart(intent, startId)
+    }
 
     override fun onNewToken(token: String) {
         if (dataStore.userStatus == UserStatus.UNAUTHENTICATED.name) return
-        scope.launch {
+        lifecycleScope.launch {
             dataStore.pushToken = token
             registerPushTokenUseCase.invoke(token)
         }
@@ -118,12 +136,13 @@ class SoptFirebaseMessagingService : FirebaseMessagingService() {
         )
     }
 
-    companion object {
-        const val NOTIFICATION_CHANNEL_ID = "SOPT"
+    @CallSuper
+    override fun onDestroy() {
+        dispatcher.onServicePreSuperOnDestroy()
+        super.onDestroy()
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        job.cancel()
+    companion object {
+        const val NOTIFICATION_CHANNEL_ID = "SOPT"
     }
 }


### PR DESCRIPTION
## What is this issue?
- [x] 기존 LifecycleService 코드를 활용해서 FirebaseMessagingService에 Lifecycle 적용하고 내부 CoroutineScope을 lifecycleScope으로 활용해서 만들기

## Reference
- [LifecycleService](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:lifecycle/lifecycle-service/src/main/java/androidx/lifecycle/LifecycleService.kt?q=file:androidx%2Flifecycle%2FLifecycleService.kt%20class:androidx.lifecycle.LifecycleService)
- [ServiceLifecycleDispatcher](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:lifecycle/lifecycle-service/src/main/java/androidx/lifecycle/ServiceLifecycleDispatcher.kt?q=ServiceLifecycleDispatcher) 
