### PR TITLE
feat: handle OnBackPressed

### DIFF
--- a/core/webview/src/main/java/org/sopt/official/webview/view/WebViewActivity.kt
+++ b/core/webview/src/main/java/org/sopt/official/webview/view/WebViewActivity.kt
@@ -1,6 +1,7 @@
 package org.sopt.official.webview.view
 
 import android.os.Bundle
+import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.official.common.util.viewBinding
@@ -18,7 +19,22 @@ class WebViewActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
+        handleLinkUrl()
+        handleOnBackPressed()
+    }
+
+    private fun handleLinkUrl() {
         val linkUrl = intent.getStringExtra(INTENT_URL)
         linkUrl?.let { binding.webView.loadUrl(it) }
+    }
+
+    private fun handleOnBackPressed() {
+        onBackPressedDispatcher.addCallback(owner = this) {
+            if (binding.webView.canGoBack()) {
+                binding.webView.goBack()
+            } else {
+                if (!isFinishing) finish()
+            }
+        }
     }
 }


### PR DESCRIPTION
## What is this issue?
- [x] 웹 뷰 내 백버튼 제정의

## Reference
**AS-IS : 백 버튼을 누르면 재정의되어있지 않기에 액티비티 종료**

https://github.com/sopt-makers/sopt-android/assets/108331578/638549fd-15b3-4417-867f-02e6a752fd25



**TO-BE : 백 버튼을 누르면 웹 뷰 내에서 뒤로 이동하다가 액티비티 종료**

https://github.com/sopt-makers/sopt-android/assets/108331578/a260e4b8-1d74-43f1-8a41-27a930f78a1c

## Issue
```kotlin
private fun handleOnBackPressed() {
    onBackPressedDispatcher.addCallback(owner = this) {
        if (binding.webView.canGoBack()) {
            binding.webView.goBack()
        } else {
            if (!isFinishing) finish()
        }
    }
}
```
원래는 `if (!isFinishing) finish()` 대신 `onBackPressedDispatcher.onBackPressed()` 를 사용하려고 했으나,
그렇게 되면 add한 Callback이 다시 실행되며 무한루프를 돌게 되는 것 같습니다.
현재는 크리티컬한 이슈가 없지만, 시스템의 기존 백 버튼 로직을 사용하지 못하는게 아쉽네요.. 해결법 아시는 분 계실까요 ??

close #664 