### PR TITLE
[feature/reference module] feature/soptamp에서 data/soptamp 직접 참조 수정

### DIFF
--- a/app/src/main/java/org/sopt/official/feature/notification/NotificationDetailActivity.kt
+++ b/app/src/main/java/org/sopt/official/feature/notification/NotificationDetailActivity.kt
@@ -35,6 +35,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import java.io.Serializable
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.sopt.official.R
@@ -42,7 +43,6 @@ import org.sopt.official.common.util.serializableExtra
 import org.sopt.official.common.util.viewBinding
 import org.sopt.official.data.model.notification.response.NotificationDetailResponse
 import org.sopt.official.databinding.ActivityNotificationDetailBinding
-import java.io.Serializable
 
 @AndroidEntryPoint
 class NotificationDetailActivity : AppCompatActivity() {

--- a/data/soptamp/src/main/java/org/sopt/official/data/soptamp/di/DataModule.kt
+++ b/data/soptamp/src/main/java/org/sopt/official/data/soptamp/di/DataModule.kt
@@ -28,6 +28,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 import org.sopt.official.data.soptamp.repository.ImageUploaderRepositoryImpl
 import org.sopt.official.data.soptamp.repository.RemoteMissionsRepository
 import org.sopt.official.data.soptamp.repository.RemoteRankingRepository
@@ -36,7 +37,6 @@ import org.sopt.official.domain.soptamp.repository.ImageUploaderRepository
 import org.sopt.official.domain.soptamp.repository.MissionsRepository
 import org.sopt.official.domain.soptamp.repository.RankingRepository
 import org.sopt.official.domain.soptamp.repository.StampRepository
-import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/data/soptamp/src/main/java/org/sopt/official/data/soptamp/di/DataModule.kt
+++ b/data/soptamp/src/main/java/org/sopt/official/data/soptamp/di/DataModule.kt
@@ -28,13 +28,15 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
+import org.sopt.official.data.soptamp.repository.ImageUploaderRepositoryImpl
 import org.sopt.official.data.soptamp.repository.RemoteMissionsRepository
 import org.sopt.official.data.soptamp.repository.RemoteRankingRepository
 import org.sopt.official.data.soptamp.repository.StampRepositoryImpl
+import org.sopt.official.domain.soptamp.repository.ImageUploaderRepository
 import org.sopt.official.domain.soptamp.repository.MissionsRepository
 import org.sopt.official.domain.soptamp.repository.RankingRepository
 import org.sopt.official.domain.soptamp.repository.StampRepository
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -51,4 +53,8 @@ internal abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindStampRepository(repository: StampRepositoryImpl): StampRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindImageUploaderRepository(repository: ImageUploaderRepositoryImpl): ImageUploaderRepository
 }

--- a/data/soptamp/src/main/java/org/sopt/official/data/soptamp/remote/model/response/S3URLResponse.kt
+++ b/data/soptamp/src/main/java/org/sopt/official/data/soptamp/remote/model/response/S3URLResponse.kt
@@ -2,7 +2,7 @@ package org.sopt.official.data.soptamp.remote.model.response
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import org.sopt.official.domain.soptamp.model.S3URL
+import org.sopt.official.domain.soptamp.model.ImageUploadUrl
 
 @Serializable
 data class S3URLResponse(
@@ -11,7 +11,7 @@ data class S3URLResponse(
     @SerialName("imageURL")
     val imageURL: String
 ) {
-    fun toDomain() = S3URL(
+    fun toDomain() = ImageUploadUrl(
         preSignedURL = preSignedURL,
         imageURL = imageURL
     )

--- a/data/soptamp/src/main/java/org/sopt/official/data/soptamp/repository/ImageUploaderRepositoryImpl.kt
+++ b/data/soptamp/src/main/java/org/sopt/official/data/soptamp/repository/ImageUploaderRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package org.sopt.official.data.soptamp.repository
+
+import android.content.Context
+import android.net.Uri
+import dagger.hilt.android.qualifiers.ApplicationContext
+import org.sopt.official.common.util.ContentUriRequestBody
+import org.sopt.official.data.soptamp.remote.api.S3Service
+import org.sopt.official.domain.soptamp.repository.ImageUploaderRepository
+import javax.inject.Inject
+
+class ImageUploaderRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val service: S3Service,
+) : ImageUploaderRepository {
+
+    override suspend fun uploadImage(preSignedURL: String, imageUri: String) {
+        service.putS3Image(preSignedURL, imageUri.run {
+            val uri = Uri.parse(this)
+            val requestBody = ContentUriRequestBody(context, uri)
+            requestBody
+        })
+    }
+}

--- a/data/soptamp/src/main/java/org/sopt/official/data/soptamp/repository/ImageUploaderRepositoryImpl.kt
+++ b/data/soptamp/src/main/java/org/sopt/official/data/soptamp/repository/ImageUploaderRepositoryImpl.kt
@@ -27,7 +27,7 @@ class ImageUploaderRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun getS3URL(): Result<ImageUploadUrl> {
+    override suspend fun getImageUploadURL(): Result<ImageUploadUrl> {
         return runCatching { stampService.getS3URL().toDomain() }
     }
 }

--- a/data/soptamp/src/main/java/org/sopt/official/data/soptamp/repository/ImageUploaderRepositoryImpl.kt
+++ b/data/soptamp/src/main/java/org/sopt/official/data/soptamp/repository/ImageUploaderRepositoryImpl.kt
@@ -5,19 +5,26 @@ import android.net.Uri
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.sopt.official.common.util.ContentUriRequestBody
 import org.sopt.official.data.soptamp.remote.api.S3Service
+import org.sopt.official.data.soptamp.remote.api.StampService
+import org.sopt.official.domain.soptamp.model.ImageUploadUrl
 import org.sopt.official.domain.soptamp.repository.ImageUploaderRepository
 import javax.inject.Inject
 
 class ImageUploaderRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val service: S3Service,
+    private val s3Service: S3Service,
+    private val stampService: StampService
 ) : ImageUploaderRepository {
 
     override suspend fun uploadImage(preSignedURL: String, imageUri: String) {
-        service.putS3Image(preSignedURL, imageUri.run {
+        s3Service.putS3Image(preSignedURL, imageUri.run {
             val uri = Uri.parse(this)
             val requestBody = ContentUriRequestBody(context, uri)
             requestBody
         })
+    }
+
+    override suspend fun getS3URL(): Result<ImageUploadUrl> {
+        return runCatching { stampService.getS3URL().toDomain() }
     }
 }

--- a/data/soptamp/src/main/java/org/sopt/official/data/soptamp/repository/ImageUploaderRepositoryImpl.kt
+++ b/data/soptamp/src/main/java/org/sopt/official/data/soptamp/repository/ImageUploaderRepositoryImpl.kt
@@ -3,12 +3,12 @@ package org.sopt.official.data.soptamp.repository
 import android.content.Context
 import android.net.Uri
 import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
 import org.sopt.official.common.util.ContentUriRequestBody
 import org.sopt.official.data.soptamp.remote.api.S3Service
 import org.sopt.official.data.soptamp.remote.api.StampService
 import org.sopt.official.domain.soptamp.model.ImageUploadUrl
 import org.sopt.official.domain.soptamp.repository.ImageUploaderRepository
-import javax.inject.Inject
 
 class ImageUploaderRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -17,11 +17,14 @@ class ImageUploaderRepositoryImpl @Inject constructor(
 ) : ImageUploaderRepository {
 
     override suspend fun uploadImage(preSignedURL: String, imageUri: String) {
-        s3Service.putS3Image(preSignedURL, imageUri.run {
-            val uri = Uri.parse(this)
-            val requestBody = ContentUriRequestBody(context, uri)
-            requestBody
-        })
+        s3Service.putS3Image(
+            preSignedURL,
+            imageUri.run {
+                val uri = Uri.parse(this)
+                val requestBody = ContentUriRequestBody(context, uri)
+                requestBody
+            }
+        )
     }
 
     override suspend fun getS3URL(): Result<ImageUploadUrl> {

--- a/data/soptamp/src/main/java/org/sopt/official/data/soptamp/repository/StampRepositoryImpl.kt
+++ b/data/soptamp/src/main/java/org/sopt/official/data/soptamp/repository/StampRepositoryImpl.kt
@@ -33,7 +33,6 @@ import kotlinx.serialization.json.Json
 import org.sopt.official.data.soptamp.remote.api.StampService
 import org.sopt.official.data.soptamp.remote.mapper.toData
 import org.sopt.official.domain.soptamp.model.Archive
-import org.sopt.official.domain.soptamp.model.ImageUploadUrl
 import org.sopt.official.domain.soptamp.model.Stamp
 import org.sopt.official.domain.soptamp.repository.StampRepository
 

--- a/data/soptamp/src/main/java/org/sopt/official/data/soptamp/repository/StampRepositoryImpl.kt
+++ b/data/soptamp/src/main/java/org/sopt/official/data/soptamp/repository/StampRepositoryImpl.kt
@@ -33,7 +33,7 @@ import kotlinx.serialization.json.Json
 import org.sopt.official.data.soptamp.remote.api.StampService
 import org.sopt.official.data.soptamp.remote.mapper.toData
 import org.sopt.official.domain.soptamp.model.Archive
-import org.sopt.official.domain.soptamp.model.S3URL
+import org.sopt.official.domain.soptamp.model.ImageUploadUrl
 import org.sopt.official.domain.soptamp.model.Stamp
 import org.sopt.official.domain.soptamp.repository.StampRepository
 
@@ -83,9 +83,5 @@ class StampRepositoryImpl @Inject constructor(
 
     override suspend fun deleteAllStamps(): Result<Unit> {
         return runCatching { service.deleteAllStamps() }
-    }
-
-    override suspend fun getS3URL(): Result<S3URL> {
-        return runCatching { service.getS3URL().toDomain() }
     }
 }

--- a/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/fake/FakeImageUploaderRepository.kt
+++ b/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/fake/FakeImageUploaderRepository.kt
@@ -1,7 +1,14 @@
 package org.sopt.official.domain.soptamp.fake
 
+import org.sopt.official.domain.soptamp.model.ImageUploadUrl
 import org.sopt.official.domain.soptamp.repository.ImageUploaderRepository
 
 object FakeImageUploaderRepository : ImageUploaderRepository {
+    private val fakeImageUploadUrl = ImageUploadUrl(
+        preSignedURL = "",
+        imageURL = ""
+    )
+
     override suspend fun uploadImage(preSignedURL: String, imageUri: String) {}
+    override suspend fun getS3URL(): Result<ImageUploadUrl> = runCatching { fakeImageUploadUrl }
 }

--- a/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/fake/FakeImageUploaderRepository.kt
+++ b/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/fake/FakeImageUploaderRepository.kt
@@ -1,0 +1,7 @@
+package org.sopt.official.domain.soptamp.fake
+
+import org.sopt.official.domain.soptamp.repository.ImageUploaderRepository
+
+object FakeImageUploaderRepository : ImageUploaderRepository {
+    override suspend fun uploadImage(preSignedURL: String, imageUri: String) {}
+}

--- a/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/fake/FakeImageUploaderRepository.kt
+++ b/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/fake/FakeImageUploaderRepository.kt
@@ -10,5 +10,5 @@ object FakeImageUploaderRepository : ImageUploaderRepository {
     )
 
     override suspend fun uploadImage(preSignedURL: String, imageUri: String) {}
-    override suspend fun getS3URL(): Result<ImageUploadUrl> = runCatching { fakeImageUploadUrl }
+    override suspend fun getImageUploadURL(): Result<ImageUploadUrl> = runCatching { fakeImageUploadUrl }
 }

--- a/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/fake/FakeStampRepository.kt
+++ b/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/fake/FakeStampRepository.kt
@@ -38,11 +38,6 @@ object FakeStampRepository : StampRepository {
         activityDate = ""
     )
 
-    private val fakeImageUploadUrl = ImageUploadUrl(
-        preSignedURL = "",
-        imageURL = ""
-    )
-
     override suspend fun completeMission(stamp: Stamp): Result<Archive> = runCatching { fakeArchive }
 
     override suspend fun getMissionContent(missionId: Int, nickname: String) = runCatching { fakeArchive }
@@ -52,5 +47,4 @@ object FakeStampRepository : StampRepository {
     override suspend fun deleteMission(missionId: Int) = runCatching { }
 
     override suspend fun deleteAllStamps(): Result<Unit> = runCatching { }
-    override suspend fun getS3URL(): Result<ImageUploadUrl> = runCatching { fakeImageUploadUrl }
 }

--- a/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/fake/FakeStampRepository.kt
+++ b/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/fake/FakeStampRepository.kt
@@ -25,7 +25,6 @@
 package org.sopt.official.domain.soptamp.fake
 
 import org.sopt.official.domain.soptamp.model.Archive
-import org.sopt.official.domain.soptamp.model.ImageUploadUrl
 import org.sopt.official.domain.soptamp.model.Stamp
 import org.sopt.official.domain.soptamp.repository.StampRepository
 

--- a/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/fake/FakeStampRepository.kt
+++ b/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/fake/FakeStampRepository.kt
@@ -25,7 +25,7 @@
 package org.sopt.official.domain.soptamp.fake
 
 import org.sopt.official.domain.soptamp.model.Archive
-import org.sopt.official.domain.soptamp.model.S3URL
+import org.sopt.official.domain.soptamp.model.ImageUploadUrl
 import org.sopt.official.domain.soptamp.model.Stamp
 import org.sopt.official.domain.soptamp.repository.StampRepository
 
@@ -38,7 +38,7 @@ object FakeStampRepository : StampRepository {
         activityDate = ""
     )
 
-    private val fakeS3URL = S3URL(
+    private val fakeImageUploadUrl = ImageUploadUrl(
         preSignedURL = "",
         imageURL = ""
     )
@@ -52,5 +52,5 @@ object FakeStampRepository : StampRepository {
     override suspend fun deleteMission(missionId: Int) = runCatching { }
 
     override suspend fun deleteAllStamps(): Result<Unit> = runCatching { }
-    override suspend fun getS3URL(): Result<S3URL> = runCatching { fakeS3URL }
+    override suspend fun getS3URL(): Result<ImageUploadUrl> = runCatching { fakeImageUploadUrl }
 }

--- a/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/model/ImageUploadUrl.kt
+++ b/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/model/ImageUploadUrl.kt
@@ -1,6 +1,6 @@
 package org.sopt.official.domain.soptamp.model
 
-data class S3URL(
+data class ImageUploadUrl(
     val preSignedURL: String,
     val imageURL: String
 )

--- a/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/repository/ImageUploaderRepository.kt
+++ b/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/repository/ImageUploaderRepository.kt
@@ -1,5 +1,8 @@
 package org.sopt.official.domain.soptamp.repository
 
+import org.sopt.official.domain.soptamp.model.ImageUploadUrl
+
 interface ImageUploaderRepository {
     suspend fun uploadImage(preSignedURL: String, imageUri: String)
+    suspend fun getS3URL(): Result<ImageUploadUrl>
 }

--- a/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/repository/ImageUploaderRepository.kt
+++ b/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/repository/ImageUploaderRepository.kt
@@ -1,0 +1,5 @@
+package org.sopt.official.domain.soptamp.repository
+
+interface ImageUploaderRepository {
+    suspend fun uploadImage(preSignedURL: String, imageUri: String)
+}

--- a/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/repository/ImageUploaderRepository.kt
+++ b/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/repository/ImageUploaderRepository.kt
@@ -4,5 +4,5 @@ import org.sopt.official.domain.soptamp.model.ImageUploadUrl
 
 interface ImageUploaderRepository {
     suspend fun uploadImage(preSignedURL: String, imageUri: String)
-    suspend fun getS3URL(): Result<ImageUploadUrl>
+    suspend fun getImageUploadURL(): Result<ImageUploadUrl>
 }

--- a/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/repository/StampRepository.kt
+++ b/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/repository/StampRepository.kt
@@ -25,7 +25,7 @@
 package org.sopt.official.domain.soptamp.repository
 
 import org.sopt.official.domain.soptamp.model.Archive
-import org.sopt.official.domain.soptamp.model.S3URL
+import org.sopt.official.domain.soptamp.model.ImageUploadUrl
 import org.sopt.official.domain.soptamp.model.Stamp
 
 interface StampRepository {
@@ -38,6 +38,4 @@ interface StampRepository {
     suspend fun deleteMission(missionId: Int): Result<Unit>
 
     suspend fun deleteAllStamps(): Result<Unit>
-
-    suspend fun getS3URL(): Result<S3URL>
 }

--- a/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/repository/StampRepository.kt
+++ b/domain/soptamp/src/main/kotlin/org/sopt/official/domain/soptamp/repository/StampRepository.kt
@@ -25,7 +25,6 @@
 package org.sopt.official.domain.soptamp.repository
 
 import org.sopt.official.domain.soptamp.model.Archive
-import org.sopt.official.domain.soptamp.model.ImageUploadUrl
 import org.sopt.official.domain.soptamp.model.Stamp
 
 interface StampRepository {

--- a/feature/soptamp/build.gradle.kts
+++ b/feature/soptamp/build.gradle.kts
@@ -53,7 +53,6 @@ android {
 
 dependencies {
     implementation(projects.domain.soptamp)
-    implementation(projects.data.soptamp)
     implementation(projects.domain.mypage)
     implementation(projects.core.common)
     implementation(projects.core.analytics)

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetail.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetail.kt
@@ -181,20 +181,6 @@ fun MissionDetailScreen(
             if (isEditable && isMe) {
                 Button(
                     onClick = {
-                        val imageUriList: MutableList<String> = mutableListOf()
-
-                        when (imageModel) {
-                            ImageModel.Empty -> {}
-                            is ImageModel.Local -> {
-                                (imageModel as ImageModel.Local).uri.map {
-                                    imageUriList.add(it)
-                                }
-                            }
-
-                            is ImageModel.Remote -> {}
-                        }
-                        viewModel.setImageUri(imageUriList)
-
                         viewModel.onSubmit()
                     },
                     modifier = Modifier

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetail.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetail.kt
@@ -265,7 +265,7 @@ fun MissionDetailPreview() {
         MissionDetailScreen(
             args,
             EmptyResultBackNavigator(),
-            MissionDetailViewModel(repository = FakeStampRepository, imageUploader = FakeImageUploaderRepository)
+            MissionDetailViewModel(stampRepository = FakeStampRepository, imageUploader = FakeImageUploaderRepository)
         )
     }
 }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetail.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetail.kt
@@ -265,7 +265,7 @@ fun MissionDetailPreview() {
         MissionDetailScreen(
             args,
             EmptyResultBackNavigator(),
-            MissionDetailViewModel(stampRepository = FakeStampRepository, imageUploader = FakeImageUploaderRepository)
+            MissionDetailViewModel(stampRepository = FakeStampRepository, imageUploaderRepository = FakeImageUploaderRepository)
         )
     }
 }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetail.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetail.kt
@@ -24,7 +24,6 @@
  */
 package org.sopt.official.stamp.feature.mission.detail
 
-import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -43,7 +42,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.airbnb.lottie.compose.LottieCompositionSpec
@@ -53,10 +51,8 @@ import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.result.EmptyResultBackNavigator
 import com.ramcosta.composedestinations.result.ResultBackNavigator
 import kotlinx.coroutines.delay
-import okhttp3.RequestBody
-import org.sopt.official.common.util.ContentUriRequestBody
-import org.sopt.official.data.soptamp.remote.api.FakeS3Service
 import org.sopt.official.domain.soptamp.MissionLevel
+import org.sopt.official.domain.soptamp.fake.FakeImageUploaderRepository
 import org.sopt.official.domain.soptamp.fake.FakeStampRepository
 import org.sopt.official.domain.soptamp.model.ImageModel
 import org.sopt.official.stamp.R
@@ -84,7 +80,7 @@ import org.sopt.official.stamp.util.DefaultPreview
 fun MissionDetailScreen(
     args: MissionNavArgs,
     resultNavigator: ResultBackNavigator<Boolean>,
-    viewModel: MissionDetailViewModel = hiltViewModel()
+    viewModel: MissionDetailViewModel = hiltViewModel(),
 ) {
     val (id, title, level, isCompleted, isMe, nickname) = args
     val content by viewModel.content.collectAsState("")
@@ -112,8 +108,6 @@ fun MissionDetailScreen(
         composition = lottieComposition,
         isPlaying = isSuccess
     )
-
-    val context = LocalContext.current
 
     LaunchedEffect(id, isCompleted, isMe, nickname) {
         viewModel.initMissionState(id, isCompleted, isMe, nickname)
@@ -188,7 +182,6 @@ fun MissionDetailScreen(
                 Button(
                     onClick = {
                         val imageUriList: MutableList<String> = mutableListOf()
-//                         val requestBodyList: MutableList<RequestBody> = mutableListOf()
 
                         when (imageModel) {
                             ImageModel.Empty -> {}
@@ -196,17 +189,11 @@ fun MissionDetailScreen(
                                 (imageModel as ImageModel.Local).uri.map {
                                     imageUriList.add(it)
                                 }
-//                                (imageModel as ImageModel.Local).uri.map {
-//                                    val uri = Uri.parse(it)
-//                                    val requestBody = ContentUriRequestBody(context, uri)
-//                                    requestBodyList.add(requestBody)
-//                                }
                             }
 
                             is ImageModel.Remote -> {}
                         }
                         viewModel.setImageUri(imageUriList)
-//                         viewModel.setRequestBody(requestBodyList)
 
                         viewModel.onSubmit()
                     },
@@ -278,7 +265,7 @@ fun MissionDetailPreview() {
         MissionDetailScreen(
             args,
             EmptyResultBackNavigator(),
-            // MissionDetailViewModel(repository = FakeStampRepository, service = FakeS3Service)
+            MissionDetailViewModel(repository = FakeStampRepository, imageUploader = FakeImageUploaderRepository)
         )
     }
 }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetail.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetail.kt
@@ -187,21 +187,26 @@ fun MissionDetailScreen(
             if (isEditable && isMe) {
                 Button(
                     onClick = {
-                        val requestBodyList: MutableList<RequestBody> = mutableListOf()
+                        val imageUriList: MutableList<String> = mutableListOf()
+//                         val requestBodyList: MutableList<RequestBody> = mutableListOf()
 
                         when (imageModel) {
                             ImageModel.Empty -> {}
                             is ImageModel.Local -> {
                                 (imageModel as ImageModel.Local).uri.map {
-                                    val uri = Uri.parse(it)
-                                    val requestBody = ContentUriRequestBody(context, uri)
-                                    requestBodyList.add(requestBody)
+                                    imageUriList.add(it)
                                 }
+//                                (imageModel as ImageModel.Local).uri.map {
+//                                    val uri = Uri.parse(it)
+//                                    val requestBody = ContentUriRequestBody(context, uri)
+//                                    requestBodyList.add(requestBody)
+//                                }
                             }
 
                             is ImageModel.Remote -> {}
                         }
-                        viewModel.setRequestBody(requestBodyList)
+                        viewModel.setImageUri(imageUriList)
+//                         viewModel.setRequestBody(requestBodyList)
 
                         viewModel.onSubmit()
                     },
@@ -273,7 +278,7 @@ fun MissionDetailPreview() {
         MissionDetailScreen(
             args,
             EmptyResultBackNavigator(),
-            MissionDetailViewModel(repository = FakeStampRepository, service = FakeS3Service)
+            // MissionDetailViewModel(repository = FakeStampRepository, service = FakeS3Service)
         )
     }
 }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
@@ -234,7 +234,7 @@ class MissionDetailViewModel @Inject constructor(
             if (imageUri is ImageModel.Remote) {
                 modifyMission(id, image, content, date)
             } else {
-                imageUploaderRepository.getS3URL().onSuccess { S3URL ->
+                imageUploaderRepository.getImageUploadURL().onSuccess { S3URL ->
                     val preSignedURL = S3URL.preSignedURL
                     val imageURL = S3URL.imageURL
 

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
@@ -35,8 +35,6 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import okhttp3.RequestBody
-import org.sopt.official.data.soptamp.remote.api.S3Service
 import org.sopt.official.domain.soptamp.model.Archive
 import org.sopt.official.domain.soptamp.model.ImageModel
 import org.sopt.official.domain.soptamp.model.Stamp
@@ -79,7 +77,6 @@ data class PostUiState(
 class MissionDetailViewModel @Inject constructor(
     private val repository: StampRepository,
     private val imageUploader: ImageUploaderRepository,
-    private val service: S3Service,
 ) : ViewModel() {
     private val uiState = MutableStateFlow(PostUiState())
 
@@ -102,7 +99,6 @@ class MissionDetailViewModel @Inject constructor(
     val isBottomSheetOpened = uiState.map { it.isBottomSheetOpened }
 
     private val submitEvent = MutableSharedFlow<Unit>()
-    private var requestbody: List<RequestBody>? = null
     private var imageUriList: List<String>? = null
 
     init {
@@ -214,10 +210,6 @@ class MissionDetailViewModel @Inject constructor(
         }
     }
 
-    fun setRequestBody(body: List<RequestBody>) {
-        requestbody = body
-    }
-
     fun setImageUri(list: List<String>) {
         imageUriList = list
     }
@@ -230,7 +222,7 @@ class MissionDetailViewModel @Inject constructor(
                 it.copy(isError = false, error = null, isLoading = true)
             }
 
-            if (uiState.value.isCompleted && requestbody.isNullOrEmpty()) {
+            if (uiState.value.isCompleted && imageUriList.isNullOrEmpty()) {
                 val image = when (imageUri) {
                     ImageModel.Empty -> {
                         "ERROR"
@@ -254,15 +246,8 @@ class MissionDetailViewModel @Inject constructor(
                     runCatching {
                         imageUploader.uploadImage(
                             preSignedURL = preSignedURL,
-                            imageUri = imageUriList?.get(0) ?:""
+                            imageUri = imageUriList?.get(0) ?: ""
                         )
-
-//                        requestbody?.map {
-//                            service.putS3Image(
-//                                preSignedURL = preSignedURL,
-//                                image = it
-//                            )
-//                        }
                     }.onFailure {
                         Timber.e(it.toString())
                     }

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
@@ -27,6 +27,7 @@ package org.sopt.official.stamp.feature.mission.detail
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -43,7 +44,6 @@ import org.sopt.official.domain.soptamp.repository.StampRepository
 import org.sopt.official.stamp.designsystem.component.toolbar.ToolbarIconType
 import retrofit2.HttpException
 import timber.log.Timber
-import javax.inject.Inject
 
 data class PostUiState(
     val id: Int = -1,

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
@@ -231,7 +231,7 @@ class MissionDetailViewModel @Inject constructor(
                 }
             }
 
-            if (uiState.value.isCompleted) {
+            if (imageUri is ImageModel.Remote) {
                 modifyMission(id, image, content, date)
             } else {
                 imageUploaderRepository.getS3URL().onSuccess { S3URL ->


### PR DESCRIPTION
## What is this issue?
closed #695  
- [x] data 직접참조 해결

## To Reviewer
- 기존 구조에서는 Screen(presentation layer)에서 Request Body를 만들어서 Service(data layer)에 넘겨주는 방식이었습니다. 
- 이 구조를 유지하기 위해서는 Repository(domain layer)에 Request Body를 넘겨줘야하는데 이는 Domain Layer에 retrofit관련 의존성을 추가해줘야 했습니다.
- 이를 해결하기 위해 Uri를 String으로 넘겨주고, RepositoryImpl에서 context를 활용해 RequestBody로 변환해 통신을 하도록 하였습니다.
- 추가적으로 Image관련된 부분은 하나의 Repository에서 관리하는게 맞다고 생각되어 기존 soptampRepository에 있던 함수 하나를 ImageUploaderRepository에 옮겨주었습니다!
- Domain에 존재하는 네이밍은 S3, Remote와 관련이 없도록 종속성을 제거한 네이밍으로 수정했습니다 :)
- 근데 모듈 그래프를 만들어서 같이 올리고 싶었는데 혹시 어떻게 하나요...?
