### PR TITLE
[refactor/#708] attendance Time Format 방식 수정

### DIFF
--- a/app/src/main/java/org/sopt/official/data/model/attendance/SoptEventResponse.kt
+++ b/app/src/main/java/org/sopt/official/data/model/attendance/SoptEventResponse.kt
@@ -86,14 +86,14 @@ data class SoptEventResponse(
             val endAtDateTime = LocalDateTime.parse(endAt)
 
             if (startAtDateTime.date == endAtDateTime.date) {
-                "${startAtDateTime.monthNumber}월 ${startAtDateTime.dayOfMonth}일 " +
-                    "${timeFormat.format(startAtDateTime)} - " +
-                    timeFormat.format(endAtDateTime)
+                "${startAtDateTime.monthNumber}\uC6D4 ${startAtDateTime.dayOfMonth}\uC77C " +
+                    "${getTimeFormat().format(startAtDateTime)} - " +
+                    getTimeFormat().format(endAtDateTime)
             } else {
-                "${startAtDateTime.monthNumber}월 ${startAtDateTime.dayOfMonth}일 " +
-                    "${timeFormat.format(startAtDateTime)} - " +
-                    "${endAtDateTime.monthNumber}월 ${endAtDateTime.dayOfMonth}일 " +
-                    timeFormat.format(endAtDateTime)
+                "${startAtDateTime.monthNumber}\uC6D4 ${startAtDateTime.dayOfMonth}\uC77C " +
+                    "${getTimeFormat().format(startAtDateTime)} - " +
+                    "${endAtDateTime.monthNumber}\uC6D4 ${endAtDateTime.dayOfMonth}\uC77C " +
+                    getTimeFormat().format(endAtDateTime)
             }
         } else {
             ""


### PR DESCRIPTION
## What is this issue?
- [x] 새로 추가된 포매터를 활용해서 kotlinx.datetime 형식의 포맷 방식을 수정합니다.

## Reference
- 수정 전 UI
<img src="https://github.com/user-attachments/assets/c9d261d3-08af-42a7-b6c6-66370e2ee5da" alt="description" width="400"/>

- 수정 후 UI
<img src="https://github.com/user-attachments/assets/e215001d-2484-4769-8cc0-7e7a2de52833" alt="description" width="400"/>


## Etc
기존 UI와 똑같이 뜬다면 잘 변경한 걸까요..?
