### PR TITLE
[feature/#960] datapicker error

### DIFF
--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/component/DatePicker.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/component/DatePicker.kt
@@ -41,7 +41,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon


### PR DESCRIPTION
## What is this issue?
- [x] 데이터피커에서 월의 마지막 날에 오류가 발생해서 앱이 꺼지던 현상 해결
    - 배경 : 현재달은 31까지 존재, 이전달은 31일 미만으로 존재
    - 발생 원리 : 날짜는 31일을 불러오고, 리스트는 30일까지만 존재하게 됨. -> 31번 index가 미관을 위해 넣어둔 공백""에 도달. -> "".toInt()가 진행되며 오류 발생

## ToReviewer
- [Compose UI Test Code](https://developer.android.com/codelabs/jetpack-compose-testing?hl=ko#0)를 작성해보려고 했는데 현재 구조상 테스트하는 것이 힘들 것 같아서 어떻게 해야할지 조언을 구하려고 왔습니다.
- 외부에서 연월일을 구하고, 내부에서 즉각적으로 사용하고 있는데 연월일을 넣었을 때 오류가 나는지 테스트 하려면 해당 값을 매개변수로 받아오는 방법으로 변경해야 할 것 같습니다. 그런데 이게 맞는 방법인지 감이 안잡히네요. 해당 컴포넌트를 쓸 때마다 연월일을 넣어주는 과정은 불필요하다 느껴지니 기본값으로 current-들을 넣어두고 사용자가 커스텀하게 하는게 좋은 방법일까요?
- 테스터블한 코드를 짜는것의 중요성을 직접 테스트 코드를 짜려고 하니 느껴지네요...

```
// 현재 구조

// 외부 선언
private val currentYear = Calendar.getInstance().get(Calendar.YEAR)
private val currentMonth = Calendar.getInstance().get(Calendar.MONTH)
private val currentDay = Calendar.getInstance().get(Calendar.DAY_OF_MONTH)

// 컴포넌트 내부
var chosenYear by remember { mutableIntStateOf(currentYear) }
var chosenMonth by remember { mutableIntStateOf(currentMonth + 1) }
var chosenDay by remember { mutableIntStateOf(currentDay) }
```
```
// 이렇게 하면 연월일을 테스트할 수 있는 테스터블한 객체가 될수 있을지 고민입니다
@Composable
fun DataPickerBottomSheet(
    year: Int = currentYear,
    month: Int = currentMonth + 1,
    day: Int = currentDay,
    onSelected: (String) -> Unit,
    onDismissRequest: () -> Unit
) {
    val sheetState = rememberModalBottomSheetState()

    val formatter = SimpleDateFormat("yyyy.MM.dd", Locale.KOREA)
    var chosenYear by remember { mutableIntStateOf(year) }
    var chosenMonth by remember { mutableIntStateOf(month) }
    var chosenDay by remember { mutableIntStateOf(day) }

    ...
}
```


