### PR TITLE
[FEAT/#1277] 홈 플그영역에서 프로필 이동 기능 구현

### DIFF
--- a/data/home/src/main/java/org/sopt/official/data/home/mapper/HomeMapper.kt
+++ b/data/home/src/main/java/org/sopt/official/data/home/mapper/HomeMapper.kt
@@ -91,7 +91,8 @@ internal fun HomeFloatingToastDto.toDomain(): FloatingToast = FloatingToast(
 )
 
 internal fun HomePopularPostResponseDto.toDomain(): PopularPost = PopularPost(
-    profileImage = this.profileImage,
+    userId = this.userId,
+    profileImage = this.profileImage.orEmpty(),
     name = this.name,
     generationAndPart = this.generationAndPart,
     rank = this.rank,
@@ -103,6 +104,7 @@ internal fun HomePopularPostResponseDto.toDomain(): PopularPost = PopularPost(
 )
 
 internal fun HomeLatestPostResponseDto.toDomain(): LatestPost = LatestPost(
+    userId = this.userId,
     profileImage = this.profileImage ?: "",
     name = this.name ?: "",
     generationAndPart = this.generationAndPart ?: "",

--- a/data/home/src/main/java/org/sopt/official/data/home/remote/response/HomeLatestPostsResponseDto.kt
+++ b/data/home/src/main/java/org/sopt/official/data/home/remote/response/HomeLatestPostsResponseDto.kt
@@ -11,6 +11,8 @@ data class HomeLatestPostsResponseDto(
 
 @Serializable
 data class HomeLatestPostResponseDto(
+    @SerialName("userId")
+    val userId: Int?,
     @SerialName("profileImage")
     val profileImage: String?,
     @SerialName("name")

--- a/data/home/src/main/java/org/sopt/official/data/home/remote/response/HomePopularPostsResponseDto.kt
+++ b/data/home/src/main/java/org/sopt/official/data/home/remote/response/HomePopularPostsResponseDto.kt
@@ -11,8 +11,10 @@ data class HomePopularPostsResponseDto(
 
 @Serializable
 data class HomePopularPostResponseDto(
+    @SerialName("userId")
+    val userId: Int?,
     @SerialName("profileImage")
-    val profileImage: String,
+    val profileImage: String?,
     @SerialName("name")
     val name: String,
     @SerialName("generationAndPart")

--- a/domain/home/src/main/java/org/sopt/official/domain/home/model/LatestPost.kt
+++ b/domain/home/src/main/java/org/sopt/official/domain/home/model/LatestPost.kt
@@ -1,6 +1,7 @@
 package org.sopt.official.domain.home.model
 
 data class LatestPost(
+    val userId: Int?,
     val profileImage: String,
     val name: String,
     val generationAndPart: String,

--- a/domain/home/src/main/java/org/sopt/official/domain/home/model/PopularPost.kt
+++ b/domain/home/src/main/java/org/sopt/official/domain/home/model/PopularPost.kt
@@ -1,6 +1,7 @@
 package org.sopt.official.domain.home.model
 
 data class PopularPost(
+    val userId: Int?,
     val profileImage: String,
     val name: String,
     val generationAndPart: String,

--- a/feature/home/src/main/java/org/sopt/official/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/HomeRoute.kt
@@ -312,6 +312,7 @@ private fun HomeScreenForMember(
             HomePopularNewsSection(
                 postList = popularPosts,
                 navigateToWebLink = homeAppServicesNavigation::navigateToWebUrl,
+                navigateToMemberProfile = homeAppServicesNavigation::navigateToPlaygroundMemberProfile,
                 modifier = Modifier
                     .padding(horizontal = 20.dp)
             )
@@ -322,7 +323,8 @@ private fun HomeScreenForMember(
                 HomeLatestNewsSection(
                     feedList = latestPosts,
                     navigateToPlayground = homeShortcutNavigation::navigateToPlayground,
-                    navigateToWebLink = homeAppServicesNavigation::navigateToWebUrl
+                    navigateToWebLink = homeAppServicesNavigation::navigateToWebUrl,
+                    navigateToMemberProfile = homeAppServicesNavigation::navigateToPlaygroundMemberProfile
                 )
             }
 

--- a/feature/home/src/main/java/org/sopt/official/feature/home/component/HomeLatestNewsSection.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/component/HomeLatestNewsSection.kt
@@ -38,6 +38,7 @@ internal fun HomeLatestNewsSection(
     feedList: ImmutableList<HomePlaygroundPostModel>,
     navigateToPlayground: () -> Unit,
     navigateToWebLink: (String) -> Unit,
+    navigateToMemberProfile: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -95,7 +96,8 @@ internal fun HomeLatestNewsSection(
                         category = category,
                         title = title,
                         description = content,
-                        onClick = { navigateToWebLink(webLink) }
+                        onClick = { navigateToWebLink(webLink) },
+                        onProfileClick = { if (userId != null) navigateToMemberProfile(userId) }
                     )
                 }
             }

--- a/feature/home/src/main/java/org/sopt/official/feature/home/component/HomePlaygroundPost.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/component/HomePlaygroundPost.kt
@@ -42,6 +42,7 @@ internal fun HomePlaygroundPost(
     title: String,
     description: String,
     onClick: () -> Unit,
+    onProfileClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -61,6 +62,7 @@ internal fun HomePlaygroundPost(
             name = userName,
             part = userPart,
             modifier = Modifier
+                .clickable(onClick = onProfileClick)
                 .padding(top = 18.dp, bottom = 22.dp)
         )
 

--- a/feature/home/src/main/java/org/sopt/official/feature/home/component/HomePopularNewsSection.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/component/HomePopularNewsSection.kt
@@ -29,48 +29,6 @@ import org.sopt.official.designsystem.Orange500
 import org.sopt.official.designsystem.SoptTheme
 import org.sopt.official.feature.home.model.HomePlaygroundPostModel
 
-internal val feedList = persistentListOf(
-    HomePlaygroundPostModel(
-        postId = 1,
-        title = "나 메이커스팀인데 메팀 좋다",
-        content = "본문 내용은 두줄로 보여줍니다.본문 내용은 두줄로 보여줍니다.본문 내용은 두줄로 보여줍니다.본문 내용은 두줄로 보여줍니다.본문 내용은 두줄로 보여줍니다.",
-        category = "전체",
-        label = "HOT",
-        profileImage = "https://avatars.githubusercontent.com/u/98209004?v=4",
-        name = "익명의 앱븐이",
-        generationAndPart = ""
-    ),
-    HomePlaygroundPostModel(
-        postId = 2,
-        title = "제목 길이가 엄청나게 길어진다면????나 메이커스팀인데 메팀 좋다 ",
-        content = "본문 내용은 두줄로 보여줍니다.본문 내용은 두줄로 보여줍니다.본문 내용은 두줄로 보여줍니다.본문 내용은 두줄로 보여줍니다.본문 내용은 두줄로 보여줍니다.",
-        category = "전체",
-        label = "HOT",
-        profileImage = "https://avatars.githubusercontent.com/u/98209004?v=4",
-        name = "박효빈",
-        generationAndPart = "35기 안드로이드"
-    ),
-    HomePlaygroundPostModel(
-        postId = 3,
-        title = "나 메이커스팀인데 메팀 좋다",
-        content = "본문 내용이 엄청 짧다면???",
-        category = "전체",
-        label = "HOT",
-        profileImage = "https://avatars.githubusercontent.com/u/98209004?v=4",
-        name = "박효빈",
-        generationAndPart = "35기 안드로이드"
-    ),
-    HomePlaygroundPostModel(
-        postId = 4,
-        title = "사진이 없다면?",
-        content = "본문 내용은 두줄로 보여줍니다.본문 내용은 두줄로 보여줍니다.본문 내용은 두줄로 보여줍니다.",
-        category = "전체",
-        label = "HOT",
-        profileImage = "",
-        name = "박효빈",
-        generationAndPart = "35기 기획"
-    )
-)
 private const val POPULAR_NEWS_LIST_SIZE = 3
 
 @Composable

--- a/feature/home/src/main/java/org/sopt/official/feature/home/component/HomePopularNewsSection.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/component/HomePopularNewsSection.kt
@@ -35,6 +35,7 @@ private const val POPULAR_NEWS_LIST_SIZE = 3
 internal fun HomePopularNewsSection(
     postList: ImmutableList<HomePlaygroundPostModel>,
     navigateToWebLink: (String) -> Unit,
+    navigateToMemberProfile: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     var highlightedIndex by remember { mutableIntStateOf(0) }
@@ -86,6 +87,7 @@ internal fun HomePopularNewsSection(
                     onClick = {
                         navigateToWebLink(webLink)
                     },
+                    onProfileClick = { if (userId != null) navigateToMemberProfile(userId) },
                     modifier = Modifier
                         .then(
                             if (index == 0) {
@@ -122,7 +124,8 @@ private fun HomePlaygroundSectionPreview() {
                     generationAndPart = ""
                 )
             ),
-            navigateToWebLink = {}
+            navigateToWebLink = {},
+            navigateToMemberProfile = {}
         )
     }
 }

--- a/feature/home/src/main/java/org/sopt/official/feature/home/mapper/HomeModelMapper.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/mapper/HomeModelMapper.kt
@@ -50,6 +50,7 @@ internal fun FloatingToast.toModel(): HomeFloatingToastData = HomeFloatingToastD
 )
 
 internal fun PopularPost.toModel(): HomePlaygroundPostModel = HomePlaygroundPostModel(
+    userId = this.userId,
     postId = this.id,
     title = this.title,
     content = this.content,
@@ -62,6 +63,7 @@ internal fun PopularPost.toModel(): HomePlaygroundPostModel = HomePlaygroundPost
 )
 
 internal fun LatestPost.toModel(): HomePlaygroundPostModel = HomePlaygroundPostModel(
+    userId = this.userId,
     postId = this.id,
     title = this.title,
     content = this.content,

--- a/feature/home/src/main/java/org/sopt/official/feature/home/model/HomeUiState.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/model/HomeUiState.kt
@@ -111,6 +111,7 @@ internal data class HomeFloatingToastData(
 
 @Immutable
 data class HomePlaygroundPostModel(
+    val userId: Int? = null,
     val postId: Int = -1,
     val title: String = "",
     val content: String = "",

--- a/feature/home/src/main/java/org/sopt/official/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/navigation/HomeNavigation.kt
@@ -55,5 +55,6 @@ sealed interface HomeNavigation {
         fun navigateToDeepLink(url: String)
         fun navigateToWebUrl(url: String)
         fun navigateToPoke(url: String, isNewPoke: Boolean, currentDestination: Int)
+        fun navigateToPlaygroundMemberProfile(userId: Int)
     }
 }

--- a/feature/main/src/main/java/org/sopt/official/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/org/sopt/official/feature/main/MainScreen.kt
@@ -181,7 +181,13 @@ fun MainScreen(
                                         false -> applicationNavigator.getPokeActivityIntent(userStatus)
                                     }
                                 )
-                        },
+
+                            override fun navigateToPlaygroundMemberProfile(userId: Int) {
+                                context.startActivity(
+                                    getIntent("${PlaygroundWebLink.MEMBER}/$userId")
+                                )
+                            }
+                        }
                     )
 
                     soptlogNavGraph(


### PR DESCRIPTION
## What is this issue?
- [x] 프로필 영역을 클릭하면 플레이그라운드 멤버 프로필로 이동해야 해요

## To Reviewers
익명이 아닌 글들만 이동하도록 만들었어요
dev 플그가 로그인이 잘 안되네요..? 그래서 테스트를 제대로 해보진 못했지만,, 플그로 이동하는 것까진 확인했어요!
