### PR TITLE
[FIX/#1334] SwipeRefreshLayout 제거

### DIFF
--- a/core/webview/src/main/java/org/sopt/official/webview/view/WebViewActivity.kt
+++ b/core/webview/src/main/java/org/sopt/official/webview/view/WebViewActivity.kt
@@ -124,7 +124,6 @@ class WebViewActivity : AppCompatActivity() {
         }
         handleLinkUrl()
         handleOnBackPressed()
-        handleOnPullToRefresh()
     }
 
     private fun handleLinkUrl() {
@@ -144,12 +143,6 @@ class WebViewActivity : AppCompatActivity() {
             } else {
                 if (!isFinishing) finish()
             }
-        }
-    }
-
-    private fun handleOnPullToRefresh() {
-        binding.swipeRefreshLayout.setOnRefreshListener {
-            binding.webView.reload()
         }
     }
 

--- a/core/webview/src/main/res/layout/activity_web_view.xml
+++ b/core/webview/src/main/res/layout/activity_web_view.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
     MIT License
 
     Copyright (c) 2023-2025 SOPT Makers
@@ -22,9 +21,8 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 -->
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/swipe_refresh_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
@@ -35,4 +33,4 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## What is this issue?
- [x] ptr 제거

## To Reviewers
- [x] 웹뷰에서 위로 스크롤 시 pullToRefresh가 되어 사용성이 떨어지는 이슈가 있었습니다. 현재 iOS도 웹에서 지원하는 스와이프만 지원하고 있어서 안드도 동일하게 안드 내에서 추가적으로 제공하는 ptr은 제거했습니다!