### PR TITLE
[FIX/#1333] 토큰 재발급 관련 로직 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
     MIT License
 
     Copyright (c) 2022-2025 SOPT Makers
@@ -37,7 +36,7 @@
     </queries>
     <application
         android:name=".App"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/core/authimpl/src/main/java/org/sopt/official/auth/impl/di/AuthModule.kt
+++ b/core/authimpl/src/main/java/org/sopt/official/auth/impl/di/AuthModule.kt
@@ -34,9 +34,11 @@ import org.sopt.official.auth.impl.api.AuthService
 import org.sopt.official.auth.impl.local.DefaultLocalAuthDataSource
 import org.sopt.official.auth.impl.remote.DefaultRemoteAuthDataSource
 import org.sopt.official.auth.impl.repository.AuthRepositoryImpl
+import org.sopt.official.auth.impl.repository.DefaultCentralizeAuthRepository
 import org.sopt.official.auth.impl.source.LocalAuthDataSource
 import org.sopt.official.auth.impl.source.RemoteAuthDataSource
 import org.sopt.official.auth.repository.AuthRepository
+import org.sopt.official.auth.repository.CentralizeAuthRepository
 import org.sopt.official.common.di.AppRetrofit
 import org.sopt.official.common.di.Auth
 import retrofit2.Retrofit
@@ -55,6 +57,10 @@ object AuthModule {
         @Binds
         @Singleton
         fun bindAuthRepository(repository: AuthRepositoryImpl): AuthRepository
+
+        @Binds
+        @Singleton
+        fun bindCentralizeAuthRepository(repository: DefaultCentralizeAuthRepository): CentralizeAuthRepository
 
         @Binds
         @Singleton

--- a/core/authimpl/src/main/java/org/sopt/official/auth/impl/mapper/TokenMapper.kt
+++ b/core/authimpl/src/main/java/org/sopt/official/auth/impl/mapper/TokenMapper.kt
@@ -30,7 +30,7 @@ import org.sopt.official.network.model.response.ValidTokenResponse
 
 fun CentralizeToken.toRequest(): ExpiredTokenRequest =
     ExpiredTokenRequest(
-        accessToken = accessToken,
+        accessToken = "Bearer $accessToken",
         refreshToken = refreshToken
     )
 


### PR DESCRIPTION
## Related issue 🛠
- closed #1333

## Work Description ✏️
- authenticator에 mutex 적용
- 앱 진입 시 토큰 재발급 시도
- allowBackup false로 수정

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
토큰 재발급 관련 로직을 수정했습니다!
먼저 토큰이 만료된 이후 홈 뷰 진입 시 약 8개의 API가 동시에 토큰 갱신을 시도하면서 동시성 문제가 발생하여 authenticator에 mutex를 적용했습니다!
또한, 인증중앙화 이전에 앱을 접속한 유저는 인증중앙화 이후에 앱 오류 발생 및 재로그인 불가한 오류가 발생하여 앱 진입 시 토큰 재발급 갱신을 시도하고 실패 시 로그인 화면으로 이동하도록 수정했습니다
마지막으로 백업 정책으로 인해 삭제 후 재설치한 유저도 토큰이 맞지 않아 앱 진입이 불가한 문제가 있었습니다 allowBackup 파라미터를 false로 수정했습니다

이 부분 리팩토링 하고 싶은 부분이 꽤나 많이 보였는데 현재 QA 기간이 여유롭지 않아 최대한 기존 구조 내에서 수정하였습니다! 추후에 리팩토링 진행하고 꼼꼼하게 QA해서 업데이트하면 좋을 것 같아요😊