### PR TITLE
[MOD/#1530] 홈 화면 스케쥴 분기 수정

### DIFF
--- a/feature/home/src/main/java/org/sopt/official/feature/home/component/HomeAttendanceDashboard.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/component/HomeAttendanceDashboard.kt
@@ -60,6 +60,7 @@ import org.sopt.official.feature.home.model.HomeSoptScheduleModel
 import org.sopt.official.feature.home.model.Schedule
 import org.sopt.official.feature.home.model.Schedule.EVENT
 import org.sopt.official.feature.home.model.Schedule.SEMINAR
+import org.sopt.official.feature.home.model.Schedule.JOINT_SEMINAR
 import org.sopt.official.feature.home.model.Schedule.BREAK
 
 @Composable
@@ -119,6 +120,7 @@ private fun HomeScheduleTypeChip(
             color = when (schedule) {
                 EVENT -> BlueAlpha200
                 SEMINAR -> OrangeAlpha200
+                JOINT_SEMINAR -> Orange400.copy(0.2f)
                 BREAK -> Green400.copy(0.2f)
             },
             shape = RoundedCornerShape(size = 4.dp),
@@ -130,6 +132,7 @@ private fun HomeScheduleTypeChip(
             color = when (schedule) {
                 EVENT -> Blue400
                 SEMINAR -> Orange400
+                JOINT_SEMINAR -> Orange400
                 BREAK -> Green400
             },
             modifier = Modifier.padding(

--- a/feature/home/src/main/java/org/sopt/official/feature/home/component/HomeAttendanceDashboard.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/component/HomeAttendanceDashboard.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.official.designsystem.Blue400
 import org.sopt.official.designsystem.BlueAlpha200
+import org.sopt.official.designsystem.Green400
 import org.sopt.official.designsystem.Orange400
 import org.sopt.official.designsystem.OrangeAlpha200
 import org.sopt.official.designsystem.SoptTheme
@@ -59,6 +60,7 @@ import org.sopt.official.feature.home.model.HomeSoptScheduleModel
 import org.sopt.official.feature.home.model.Schedule
 import org.sopt.official.feature.home.model.Schedule.EVENT
 import org.sopt.official.feature.home.model.Schedule.SEMINAR
+import org.sopt.official.feature.home.model.Schedule.BREAK
 
 @Composable
 internal fun HomeSoptScheduleDashboard(
@@ -117,6 +119,7 @@ private fun HomeScheduleTypeChip(
             color = when (schedule) {
                 EVENT -> BlueAlpha200
                 SEMINAR -> OrangeAlpha200
+                BREAK -> Green400.copy(0.2f)
             },
             shape = RoundedCornerShape(size = 4.dp),
         )
@@ -127,6 +130,7 @@ private fun HomeScheduleTypeChip(
             color = when (schedule) {
                 EVENT -> Blue400
                 SEMINAR -> Orange400
+                BREAK -> Green400
             },
             modifier = Modifier.padding(
                 horizontal = 6.dp,

--- a/feature/home/src/main/java/org/sopt/official/feature/home/model/Schedule.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/model/Schedule.kt
@@ -27,7 +27,7 @@ package org.sopt.official.feature.home.model
 import org.sopt.official.domain.home.model.ScheduleType
 
 internal enum class Schedule(val titleKR: String) {
-    EVENT("행사"), SEMINAR("세미나")
+    EVENT("행사"), SEMINAR("세미나"), BREAK("휴식")
     ;
 
     companion object {

--- a/feature/home/src/main/java/org/sopt/official/feature/home/model/Schedule.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/model/Schedule.kt
@@ -27,7 +27,10 @@ package org.sopt.official.feature.home.model
 import org.sopt.official.domain.home.model.ScheduleType
 
 internal enum class Schedule(val titleKR: String) {
-    EVENT("행사"), SEMINAR("세미나"), BREAK("휴식")
+    EVENT("행사"),
+    SEMINAR("세미나"),
+    JOINT_SEMINAR("합동 세미나"),
+    BREAK("휴식")
     ;
 
     companion object {


### PR DESCRIPTION
## Related issue 🛠
- closed #1530 

## Work Description ✏️
- 홈 화면 스케쥴 분기 내 휴식(BREAK)를 추가했습니다.
- HomeScheduleTypeChip 휴식 색상 추가했습니다.

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅


## To Reviewers 📢
- 피그마를 열심히 찾아봤는데, 해당화면에 적용되는 color 명을 찾지 못하여, 
 동일한 컴포넌트를 사용하는 schedule 모듈의 ScheduleItem 쪽 색상과 동일하게 적용하였습니다.

<img width="1476" height="692" alt="image" src="https://github.com/user-attachments/assets/5504ae39-1efa-4c75-94c2-365015f94ad7" />
