### PR TITLE
[FIX/#1535] 출석 뷰 진입시 앱 종료 오류 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -186,6 +186,7 @@ dependencies {
     implementation(libs.semver)
 
     implementation(libs.code.gson)
+    implementation(libs.lifecycle.livedata.ktx)
 }
 
 secrets {


### PR DESCRIPTION
## Related issue 🛠
- closed #1535

## Work Description ✏️
- 출석 화면 진입 시 발생하던 크래시 수정
- `lifecycle-livedata-ktx` 의존성 명시적 추가
- `AttendanceViewModel`의 `LiveData.map` 런타임 의존성 보장

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
출석 화면 진입 시 앱이 종료되는 문제를 수정했습니다.

에러 로그상 `androidx.lifecycle.Transformations`를 찾지 못해 `ClassNotFoundException`이 발생하고 있었고, `AttendanceViewModel`에서 사용하는 `LiveData.map` 변환 로직이 런타임에서 정상적으로 로드되지 않는 상황이었습니다.

확인 결과, `lifecycle-livedata-ktx`가 앱 모듈에 명시적으로 선언되어 있지 않아
간접 의존성에 의존하고 있었고, 최근 dependency graph 변화 과정에서 해당 경로가 달라지며 크래시가 발생한 것으로 보입니다.

또한, [해당 PR](https://github.com/sopt-makers/sopt-android/pull/1499) 이후부터 문제가 재현되는 것을 확인했으며, `googleid` 업데이트로 인해 런타임 의존성 구성이 일부 변경되면서 기존에 간접적으로 지원되던 의존성이 사라졌을 가능성이 있지 않을까?? 생각했습니다. 라이브러리 내부 변경사항까지는 확인이 어려워 정확한 원인은 특정하지 못했습니다.

이에 따라 `lifecycle-livedata-ktx` 의존성을 명시적으로 추가하여 해당 문제를 해결했습니다.