### PR TITLE
[REFACTOR/#1537] 솝탬프 중복 제출 방지

### DIFF
--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
@@ -114,8 +114,8 @@ constructor(
     val date = uiState.map { it.date }
     val imageModel = uiState.map { it.imageUri }
     val isSubmitEnabled =
-        combine(content, imageModel, isMe) { content, image, isMe ->
-            content.isNotEmpty() && !image.isEmpty() && isMe
+        combine(content, imageModel, isMe, uiState.map { it.isLoading }, uiState.map { it.isSuccess }) { content, image, isMe, isLoading, isSuccess ->
+            content.isNotEmpty() && !image.isEmpty() && isMe && !isLoading && !isSuccess
         }
     val toolbarIconType = uiState.map { it.toolbarIconType }
     val isEditable =
@@ -140,15 +140,8 @@ constructor(
     private val _myNickname = MutableStateFlow("")
     val myNickname = _myNickname.asStateFlow()
 
-    private val submitEvent = MutableSharedFlow<Unit>()
-
     init {
         observeDebouncedClaps()
-        viewModelScope.launch {
-            submitEvent.debounce(500).collect {
-                handleSubmit()
-            }
-        }
     }
 
     // 딥링크로 미션 상세 뷰에 접속한 경우 "나"의 닉네임을 얻음 (앰플리튜드 삽입 목적)
@@ -214,6 +207,14 @@ constructor(
                             }
                         }
                     }
+            } else {
+                uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        isCompleted = false,
+                        toolbarIconType = ToolbarIconType.NONE
+                    )
+                }
             }
         }
     }
@@ -269,8 +270,9 @@ constructor(
     }
 
     fun onSubmit() {
+        if (uiState.value.isLoading || uiState.value.isSuccess) return
         viewModelScope.launch {
-            submitEvent.emit(Unit)
+            handleSubmit()
         }
     }
 

--- a/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
+++ b/feature/soptamp/src/main/java/org/sopt/official/stamp/feature/mission/detail/MissionDetailViewModel.kt
@@ -114,7 +114,12 @@ constructor(
     val date = uiState.map { it.date }
     val imageModel = uiState.map { it.imageUri }
     val isSubmitEnabled =
-        combine(content, imageModel, isMe, uiState.map { it.isLoading }, uiState.map { it.isSuccess }) { content, image, isMe, isLoading, isSuccess ->
+        combine(
+            content,
+            imageModel,
+            isMe,
+            uiState.map { it.isLoading },
+            uiState.map { it.isSuccess }) { content, image, isMe, isLoading, isSuccess ->
             content.isNotEmpty() && !image.isEmpty() && isMe && !isLoading && !isSuccess
         }
     val toolbarIconType = uiState.map { it.toolbarIconType }
@@ -175,15 +180,7 @@ constructor(
             if (isCompleted) {
                 stampRepository.getMissionContent(id, nickname)
                     .onSuccess {
-                        val option = if (!isMe) {
-                            ToolbarIconType.NONE
-                        } else {
-                            if (isCompleted) {
-                                ToolbarIconType.WRITE
-                            } else {
-                                ToolbarIconType.NONE
-                            }
-                        }
+                        val option = if (!isMe) ToolbarIconType.NONE else ToolbarIconType.WRITE
                         val result = PostUiState.from(it).copy(
                             stampId = it.id,
                             imageUri = ImageModel.Remote(url = it.images),


### PR DESCRIPTION
## Related issue 🛠
- closed #1537

## Work Description ✏️
- 솝탬프 중복 제출 방지
    - 제출 버튼 disabled 처리
    - onSubmit 함수 ealry return 처리

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
미션 제출 시 버튼 중복 호출을 막는 로직이 없어, 동일 요청이 여러 번 전송되면서 서버에서 에러(409)가 발생하는 문제가 있었습니다. 이 경우 네트워크 에러 다이얼로그가 노출되고, 사용자가 화면을 빠져나가기 어려운 상황이 발생했습니다.

중복호출을 막기위해 isLoading과 함께 isSuccess 상태를 추가로 체크하도록 수정했습니다. 
isLoading 만 조건을 걸면 제출 이후, 스템프 로띠가 나오기전에 잠깐 또 호출이 가능했기에 isSuccess 조건도 같이 체킹하게 하였습니다.

현재 작업은 soptamp 에만 해두고 appjamtamp 는 따로 테스트해보기가 어려워 우선 soptamp 만 작업해두었습니다.