### PR TITLE
[Fix#1555] qa fix deeplink issue

### DIFF
--- a/app/src/main/java/org/sopt/official/config/messaging/SoptFirebaseMessagingService.kt
+++ b/app/src/main/java/org/sopt/official/config/messaging/SoptFirebaseMessagingService.kt
@@ -71,8 +71,8 @@ class SoptFirebaseMessagingService : LifecycleAwareFirebaseMessagingService() {
         val notificationId = receivedData["id"] ?: ""
         val title = receivedData["title"] ?: ""
         val body = receivedData["content"] ?: ""
-        val webLink = receivedData["webLink"] ?: ""
-        val deepLink = receivedData["deepLink"] ?: ""
+        val webLink = receivedData["webLink"]?.takeIf { it != "null" } ?: ""
+        val deepLink = receivedData["deepLink"]?.takeIf { it != "null" } ?: ""
 
         val notifyId = System.currentTimeMillis().toInt()
         val notificationBuilder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID).setContentTitle(title).setContentText(body)

--- a/core/common/src/main/java/org/sopt/official/common/navigator/DeepLinkType.kt
+++ b/core/common/src/main/java/org/sopt/official/common/navigator/DeepLinkType.kt
@@ -108,19 +108,18 @@ enum class DeepLinkType(
             userStatus.setIntent(navigator.getAppjamtampActivityIntent())
     },
 
-    // TODO - 콕찌르기 이슈 해결되면 딥링크에서 home 제거해야 함 (서버 변경으로 home 제거)
-    POKE_NOTIFICATION_LIST("home/poke/notification-list") {
+    POKE_NOTIFICATION_LIST("poke/notification-list") {
         override fun getIntent(context: Context, userStatus: UserStatus, deepLink: String) =
             userStatus.setIntent(navigator.getPokeNotificationActivityIntent(userStatus.name))
     },
-    POKE_FRIEND_LIST_SUMMARY("home/poke/friend-list-summary") {
+    POKE_FRIEND_LIST_SUMMARY("poke/friend-list-summary") {
         override fun getIntent(context: Context, userStatus: UserStatus, deepLink: String): Intent {
             val friendType = deepLink.extractQueryParameter("type")
             val intent = navigator.getPokeFriendListSummaryActivityIntent(userStatus.name, friendType)
             return userStatus.setIntent(intent)
         }
     },
-    POKE("home/poke") {
+    POKE("poke") {
         override fun getIntent(context: Context, userStatus: UserStatus, deepLink: String) =
             userStatus.setIntent(navigator.getPokeActivityIntent(userStatus))
     },
@@ -166,3 +165,4 @@ enum class DeepLinkType(
 }
 
 const val SOPTLOG_FORTUNE = "soptlog/fortune"
+

--- a/feature/main/src/main/java/org/sopt/official/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/org/sopt/official/feature/main/MainScreen.kt
@@ -74,6 +74,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.compose.NavHost
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -93,6 +94,7 @@ import org.sopt.official.feature.main.MainTab.Home
 import org.sopt.official.feature.main.component.MainBottomBarAlarmBadge
 import org.sopt.official.feature.main.model.PlaygroundWebLink
 import org.sopt.official.feature.main.model.SoptWebLink
+import org.sopt.official.feature.poke.navigation.PokeNotification
 import org.sopt.official.feature.poke.navigation.navigateToPokeFriendList
 import org.sopt.official.feature.poke.navigation.navigateToPokeNotification
 import org.sopt.official.feature.poke.navigation.navigateToPokeOnboarding
@@ -200,7 +202,14 @@ fun MainScreen(
         }
 
         if (shouldNavigateToPokeNotification) {
-            navigator.navController.navigateToPokeNotification(userStatus.name, null)
+            val isAlreadyOnPokeNotification =
+                navigator.navController.currentBackStackEntry
+                    ?.destination
+                    ?.hasRoute<PokeNotification>() == true
+
+            if (!isAlreadyOnPokeNotification) {
+                navigator.navController.navigateToPokeNotification(userStatus.name, null)
+            }
             activity?.intent?.putExtra("isPokeNotification", false)
         }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #1555 

## Work Description ✏️
- DeepLink path가 서버에서 내려주는 형식의 변경에 따라 수정하였습니다
- Firebase 알림의 WebLink를 null로 내려주는데 이 값을 텍스트로 인식하는 문법 오류를 수정하였습니다
- Poke 알림 화면 이동 시 중복으로 화면 스택이 쌓이는 오류를 수정했습니다 - 승준

## To Reviewers 📢
QA 중 발견한 알림 딥링크 오류를 확인 후 그 자리에서 테스트까지 완료하였습니다!