### PR TITLE
[MOD/#1577] 콕찌르기 천생연분 세션 실명 프로필로 변경

### DIFF
--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/detail/FriendListDetailBottomSheetFragment.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/detail/FriendListDetailBottomSheetFragment.kt
@@ -62,6 +62,7 @@ import org.sopt.official.feature.poke.user.PokeUserListAdapter
 import org.sopt.official.feature.poke.user.PokeUserListClickListener
 import org.sopt.official.feature.poke.user.PokeUserListItemViewType
 import org.sopt.official.feature.poke.util.addOnAnimationEndListener
+import org.sopt.official.feature.poke.util.isAnonymousCheckboxLocked
 import org.sopt.official.feature.poke.util.isBestFriend
 import org.sopt.official.feature.poke.util.isSoulMate
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
@@ -241,6 +242,7 @@ class FriendListDetailBottomSheetFragment : BottomSheetDialogFragment() {
                 messageListBottomSheet =
                     MessageListBottomSheetFragment.Builder()
                         .setMessageListType(PokeMessageType.POKE_FRIEND)
+                        .setAnonymousCheckboxLocked(isLocked = isAnonymousCheckboxLocked(user.pokeNum))
                         .onClickMessageListItem { message, isAnonymous ->
                             viewModel.pokeUser(
                                 userId = user.userId,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/detail/FriendListDetailBottomSheetFragment.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/detail/FriendListDetailBottomSheetFragment.kt
@@ -40,7 +40,6 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -57,15 +56,17 @@ import org.sopt.official.domain.poke.type.PokeMessageType
 import org.sopt.official.feature.poke.R
 import org.sopt.official.feature.poke.UiState
 import org.sopt.official.feature.poke.databinding.FragmentFriendListDetailBottomSheetBinding
-import org.sopt.official.feature.poke.main.PokeMainActivity
 import org.sopt.official.feature.poke.message.MessageListBottomSheetFragment
 import org.sopt.official.feature.poke.user.ItemDecorationDivider
 import org.sopt.official.feature.poke.user.PokeUserListAdapter
 import org.sopt.official.feature.poke.user.PokeUserListClickListener
 import org.sopt.official.feature.poke.user.PokeUserListItemViewType
 import org.sopt.official.feature.poke.util.addOnAnimationEndListener
+import org.sopt.official.feature.poke.util.isBestFriend
+import org.sopt.official.feature.poke.util.isSoulMate
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
 import org.sopt.official.feature.poke.util.showPokeToast
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class FriendListDetailBottomSheetFragment : BottomSheetDialogFragment() {
@@ -293,7 +294,7 @@ class FriendListDetailBottomSheetFragment : BottomSheetDialogFragment() {
                     is UiState.Loading -> {}
                     is UiState.Success<PokeUser> -> {
                         messageListBottomSheet?.dismiss()
-                        if (PokeMainActivity.isBestFriend(it.data.pokeNum, it.data.isAnonymous)) {
+                        if (isBestFriend(it.data.pokeNum, it.data.isAnonymous)) {
                             with(binding) {
                                 layoutAnonymousFriendLottie.visibility = View.VISIBLE
                                 tvFreindLottie.text = getString(R.string.anonymous_to_friend, it.data.anonymousName, "단짝친구가")
@@ -303,7 +304,7 @@ class FriendListDetailBottomSheetFragment : BottomSheetDialogFragment() {
                                     setAnimation(R.raw.friendtobestfriend)
                                 }.playAnimation()
                             }
-                        } else if (PokeMainActivity.isSoulMate(it.data.pokeNum, it.data.isAnonymous)) {
+                        } else if (isSoulMate(it.data.pokeNum)) {
                             viewModel.setAnonymousFriend(it.data)
                             with(binding) {
                                 layoutAnonymousFriendLottie.visibility = View.VISIBLE

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/detail/FriendListDetailBottomSheetFragment.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/detail/FriendListDetailBottomSheetFragment.kt
@@ -65,6 +65,7 @@ import org.sopt.official.feature.poke.util.addOnAnimationEndListener
 import org.sopt.official.feature.poke.util.isBestFriend
 import org.sopt.official.feature.poke.util.isSoulMate
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
+import org.sopt.official.feature.poke.util.isAnonymousCheckboxVisible
 import org.sopt.official.feature.poke.util.showPokeToast
 import javax.inject.Inject
 
@@ -241,6 +242,7 @@ class FriendListDetailBottomSheetFragment : BottomSheetDialogFragment() {
                 messageListBottomSheet =
                     MessageListBottomSheetFragment.Builder()
                         .setMessageListType(PokeMessageType.POKE_FRIEND)
+                        .setAnonymousCheckboxVisible(isVisible = isAnonymousCheckboxVisible(user.pokeNum))
                         .onClickMessageListItem { message, isAnonymous ->
                             viewModel.pokeUser(
                                 userId = user.userId,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/detail/FriendListDetailBottomSheetFragment.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/detail/FriendListDetailBottomSheetFragment.kt
@@ -65,7 +65,6 @@ import org.sopt.official.feature.poke.util.addOnAnimationEndListener
 import org.sopt.official.feature.poke.util.isBestFriend
 import org.sopt.official.feature.poke.util.isSoulMate
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
-import org.sopt.official.feature.poke.util.isAnonymousCheckboxVisible
 import org.sopt.official.feature.poke.util.showPokeToast
 import javax.inject.Inject
 
@@ -242,7 +241,6 @@ class FriendListDetailBottomSheetFragment : BottomSheetDialogFragment() {
                 messageListBottomSheet =
                     MessageListBottomSheetFragment.Builder()
                         .setMessageListType(PokeMessageType.POKE_FRIEND)
-                        .setAnonymousCheckboxVisible(isVisible = isAnonymousCheckboxVisible(user.pokeNum))
                         .onClickMessageListItem { message, isAnonymous ->
                             viewModel.pokeUser(
                                 userId = user.userId,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/summary/FriendListSummaryActivity.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/summary/FriendListSummaryActivity.kt
@@ -67,7 +67,6 @@ import org.sopt.official.feature.poke.user.PokeUserListItemViewType
 import org.sopt.official.feature.poke.util.addOnAnimationEndListener
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
 import org.sopt.official.feature.poke.util.showPokeToast
-import org.sopt.official.feature.poke.util.isAnonymousCheckboxVisible
 
 @Deprecated("FriendListSummaryScreen으로 대체")
 @AndroidEntryPoint
@@ -306,7 +305,6 @@ class FriendListSummaryActivity : AppCompatActivity() {
                 messageListBottomSheet =
                     MessageListBottomSheetFragment.Builder()
                         .setMessageListType(PokeMessageType.POKE_FRIEND)
-                        .setAnonymousCheckboxVisible(isVisible = isAnonymousCheckboxVisible(user.pokeNum))
                         .onClickMessageListItem { message, isAnonymous ->
                             viewModel.pokeUser(
                                 userId = user.userId,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/summary/FriendListSummaryActivity.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/summary/FriendListSummaryActivity.kt
@@ -67,6 +67,7 @@ import org.sopt.official.feature.poke.user.PokeUserListItemViewType
 import org.sopt.official.feature.poke.util.addOnAnimationEndListener
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
 import org.sopt.official.feature.poke.util.showPokeToast
+import org.sopt.official.feature.poke.util.isAnonymousCheckboxVisible
 
 @Deprecated("FriendListSummaryScreen으로 대체")
 @AndroidEntryPoint
@@ -305,6 +306,7 @@ class FriendListSummaryActivity : AppCompatActivity() {
                 messageListBottomSheet =
                     MessageListBottomSheetFragment.Builder()
                         .setMessageListType(PokeMessageType.POKE_FRIEND)
+                        .setAnonymousCheckboxVisible(isVisible = isAnonymousCheckboxVisible(user.pokeNum))
                         .onClickMessageListItem { message, isAnonymous ->
                             viewModel.pokeUser(
                                 userId = user.userId,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/summary/FriendListSummaryActivity.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/summary/FriendListSummaryActivity.kt
@@ -65,6 +65,7 @@ import org.sopt.official.feature.poke.user.PokeUserListAdapter
 import org.sopt.official.feature.poke.user.PokeUserListClickListener
 import org.sopt.official.feature.poke.user.PokeUserListItemViewType
 import org.sopt.official.feature.poke.util.addOnAnimationEndListener
+import org.sopt.official.feature.poke.util.isAnonymousCheckboxLocked
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
 import org.sopt.official.feature.poke.util.showPokeToast
 
@@ -305,6 +306,7 @@ class FriendListSummaryActivity : AppCompatActivity() {
                 messageListBottomSheet =
                     MessageListBottomSheetFragment.Builder()
                         .setMessageListType(PokeMessageType.POKE_FRIEND)
+                        .setAnonymousCheckboxLocked(isAnonymousCheckboxLocked(user.pokeNum))
                         .onClickMessageListItem { message, isAnonymous ->
                             viewModel.pokeUser(
                                 userId = user.userId,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/summary/FriendListSummaryScreen.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/summary/FriendListSummaryScreen.kt
@@ -76,6 +76,7 @@ import org.sopt.official.feature.poke.util.isBestFriend
 import org.sopt.official.feature.poke.util.isSoulMate
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
 import org.sopt.official.feature.poke.util.showPokeToast
+import org.sopt.official.feature.poke.util.isAnonymousCheckboxVisible
 import org.sopt.official.model.UserStatus
 
 @Composable
@@ -142,6 +143,7 @@ fun FriendListSummaryScreen(
                 if (fragmentManager != null) {
                     val bottomSheet = MessageListBottomSheetFragment.Builder()
                         .setMessageListType(PokeMessageType.POKE_FRIEND)
+                        .setAnonymousCheckboxVisible(isVisible = isAnonymousCheckboxVisible(user.pokeNum))
                         .onClickMessageListItem { message, isAnonymous ->
                             viewModel.pokeUser(
                                 userId = user.userId,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/summary/FriendListSummaryScreen.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/summary/FriendListSummaryScreen.kt
@@ -200,7 +200,7 @@ fun FriendListSummaryScreen(
 
                     val user = state.data
                     val isBestFriend = isBestFriend(user.pokeNum, user.isAnonymous)
-                    val isSoulMate = isSoulMate(user.pokeNum, user.isAnonymous)
+                    val isSoulMate = isSoulMate(user.pokeNum)
 
                     if (!isBestFriend && !isSoulMate) {
                         fragmentActivity?.showPokeToast(context.getString(R.string.toast_poke_user_success))

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/summary/FriendListSummaryScreen.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/summary/FriendListSummaryScreen.kt
@@ -76,7 +76,6 @@ import org.sopt.official.feature.poke.util.isBestFriend
 import org.sopt.official.feature.poke.util.isSoulMate
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
 import org.sopt.official.feature.poke.util.showPokeToast
-import org.sopt.official.feature.poke.util.isAnonymousCheckboxVisible
 import org.sopt.official.model.UserStatus
 
 @Composable
@@ -143,7 +142,6 @@ fun FriendListSummaryScreen(
                 if (fragmentManager != null) {
                     val bottomSheet = MessageListBottomSheetFragment.Builder()
                         .setMessageListType(PokeMessageType.POKE_FRIEND)
-                        .setAnonymousCheckboxVisible(isVisible = isAnonymousCheckboxVisible(user.pokeNum))
                         .onClickMessageListItem { message, isAnonymous ->
                             viewModel.pokeUser(
                                 userId = user.userId,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/summary/FriendListSummaryScreen.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/friend/summary/FriendListSummaryScreen.kt
@@ -73,6 +73,7 @@ import org.sopt.official.feature.poke.user.PokeUserListItemViewType
 import org.sopt.official.feature.poke.util.addOnAnimationEndListener
 import org.sopt.official.feature.poke.util.dismissBottomSheet
 import org.sopt.official.feature.poke.util.isBestFriend
+import org.sopt.official.feature.poke.util.isAnonymousCheckboxLocked
 import org.sopt.official.feature.poke.util.isSoulMate
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
 import org.sopt.official.feature.poke.util.showPokeToast
@@ -142,6 +143,7 @@ fun FriendListSummaryScreen(
                 if (fragmentManager != null) {
                     val bottomSheet = MessageListBottomSheetFragment.Builder()
                         .setMessageListType(PokeMessageType.POKE_FRIEND)
+                        .setAnonymousCheckboxLocked(isLocked = isAnonymousCheckboxLocked(user.pokeNum))
                         .onClickMessageListItem { message, isAnonymous ->
                             viewModel.pokeUser(
                                 userId = user.userId,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/main/PokeScreen.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/main/PokeScreen.kt
@@ -65,6 +65,7 @@ import org.sopt.official.feature.poke.user.PokeUserListClickListener
 import org.sopt.official.feature.poke.util.addOnAnimationEndListener
 import org.sopt.official.feature.poke.util.dismissBottomSheet
 import org.sopt.official.feature.poke.util.isBestFriend
+import org.sopt.official.feature.poke.util.isAnonymousCheckboxLocked
 import org.sopt.official.feature.poke.util.isSoulMate
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
 import org.sopt.official.feature.poke.util.showPokeToast
@@ -406,6 +407,7 @@ private fun initPokeMeView(
                     false -> PokeMessageType.POKE_FRIEND
                 },
                 pokeMeItem.isFirstMeet,
+                isAnonymousCheckboxLocked = isAnonymousCheckboxLocked(pokeMeItem.pokeNum),
             )
         }
     }
@@ -472,6 +474,7 @@ private fun initPokeFriendView(
                 viewModel = viewModel,
                 userId = pokeFriendItem.userId,
                 pokeMessageType = PokeMessageType.POKE_FRIEND,
+                isAnonymousCheckboxLocked = isAnonymousCheckboxLocked(pokeFriendItem.pokeNum),
             )
         }
     }
@@ -483,10 +486,12 @@ private fun showMessageListBottomSheet(
     userId: Int,
     pokeMessageType: PokeMessageType,
     isFirstMeet: Boolean = false,
+    isAnonymousCheckboxLocked: Boolean = false,
 ) {
     val messageListBottomSheet =
         MessageListBottomSheetFragment.Builder()
             .setMessageListType(pokeMessageType)
+            .setAnonymousCheckboxLocked(isAnonymousCheckboxLocked)
             .onClickMessageListItem { message, isAnonymous ->
                 viewModel.pokeUser(
                     userId = userId,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/main/PokeScreen.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/main/PokeScreen.kt
@@ -64,7 +64,6 @@ import org.sopt.official.feature.poke.message.MessageListBottomSheetFragment
 import org.sopt.official.feature.poke.user.PokeUserListClickListener
 import org.sopt.official.feature.poke.util.addOnAnimationEndListener
 import org.sopt.official.feature.poke.util.dismissBottomSheet
-import org.sopt.official.feature.poke.util.isAnonymousVisible
 import org.sopt.official.feature.poke.util.isBestFriend
 import org.sopt.official.feature.poke.util.isSoulMate
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
@@ -349,7 +348,7 @@ private fun initPokeMeView(
     viewModel: PokeMainViewModel
 ) {
     val context = binding.root.context
-    val isAnonymousVisible = isAnonymousVisible(pokeMeItem.isAnonymous, pokeMeItem.relationName)
+    val isAnonymousVisible = pokeMeItem.isAnonymous
     with(binding) {
         layoutSomeonePokeMe.setVisible(true)
         imgUserProfileSomeonePokeMe.setOnClickListener {
@@ -421,7 +420,7 @@ private fun initPokeFriendView(
     viewModel: PokeMainViewModel
 ) {
     val context = binding.root.context
-    val isAnonymousVisible = isAnonymousVisible(pokeFriendItem.isAnonymous, pokeFriendItem.relationName)
+    val isAnonymousVisible = pokeFriendItem.isAnonymous
     with(binding) {
         imgUserProfilePokeMyFriend.setOnClickListener {
             if (isAnonymousVisible) return@setOnClickListener

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/main/PokeScreen.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/main/PokeScreen.kt
@@ -67,6 +67,7 @@ import org.sopt.official.feature.poke.util.dismissBottomSheet
 import org.sopt.official.feature.poke.util.isBestFriend
 import org.sopt.official.feature.poke.util.isSoulMate
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
+import org.sopt.official.feature.poke.util.isAnonymousCheckboxVisible
 import org.sopt.official.feature.poke.util.showPokeToast
 import org.sopt.official.model.UserStatus
 
@@ -405,6 +406,7 @@ private fun initPokeMeView(
                     false -> PokeMessageType.POKE_FRIEND
                 },
                 pokeMeItem.isFirstMeet,
+                isAnonymousCheckboxVisible = true,
             )
         }
     }
@@ -465,7 +467,13 @@ private fun initPokeFriendView(
                         "view_profile" to pokeFriendItem.userId,
                     ),
             )
-            showMessageListBottomSheet(activity, viewModel, pokeFriendItem.userId, PokeMessageType.POKE_FRIEND)
+            showMessageListBottomSheet(
+                activity = activity,
+                viewModel = viewModel,
+                userId = pokeFriendItem.userId,
+                pokeMessageType = PokeMessageType.POKE_FRIEND,
+                isAnonymousCheckboxVisible = isAnonymousCheckboxVisible(pokeFriendItem.pokeNum),
+            )
         }
     }
 }
@@ -476,10 +484,12 @@ private fun showMessageListBottomSheet(
     userId: Int,
     pokeMessageType: PokeMessageType,
     isFirstMeet: Boolean = false,
+    isAnonymousCheckboxVisible: Boolean = true,
 ) {
     val messageListBottomSheet =
         MessageListBottomSheetFragment.Builder()
             .setMessageListType(pokeMessageType)
+            .setAnonymousCheckboxVisible(isAnonymousCheckboxVisible)
             .onClickMessageListItem { message, isAnonymous ->
                 viewModel.pokeUser(
                     userId = userId,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/main/PokeScreen.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/main/PokeScreen.kt
@@ -68,7 +68,6 @@ import org.sopt.official.feature.poke.util.isBestFriend
 import org.sopt.official.feature.poke.util.isSoulMate
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
 import org.sopt.official.feature.poke.util.showPokeToast
-import org.sopt.official.feature.poke.util.toSafeAnonymousImageUrl
 import org.sopt.official.model.UserStatus
 
 private const val MESSAGE_LIST_BOTTOM_SHEET_TAG = "MessageListBottomSheet"
@@ -207,6 +206,7 @@ fun PokeScreen(
                     currentBinding.layoutPokeMyFriend.setVisible(false)
                     activity?.showPokeToast(state.throwable.message ?: context.getString(R.string.toast_poke_error))
                 }
+
                 else -> {}
             }
         }
@@ -239,7 +239,7 @@ fun PokeScreen(
                                 animationFriendViewLottie.setAnimation(R.raw.friendtobestfriend)
                                 animationFriendViewLottie.playAnimation()
                             }
-                        } else if (isSoulMate(user.pokeNum, user.isAnonymous)) {
+                        } else if (isSoulMate(user.pokeNum)) {
                             viewModel.setAnonymousFriend(user)
                             with(currentBinding) {
                                 layoutAnonymousFriendLottie.visibility = View.VISIBLE

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/main/PokeScreen.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/main/PokeScreen.kt
@@ -68,7 +68,6 @@ import org.sopt.official.feature.poke.util.isAnonymousVisible
 import org.sopt.official.feature.poke.util.isBestFriend
 import org.sopt.official.feature.poke.util.isSoulMate
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
-import org.sopt.official.feature.poke.util.isAnonymousCheckboxVisible
 import org.sopt.official.feature.poke.util.showPokeToast
 import org.sopt.official.model.UserStatus
 
@@ -408,7 +407,6 @@ private fun initPokeMeView(
                     false -> PokeMessageType.POKE_FRIEND
                 },
                 pokeMeItem.isFirstMeet,
-                isAnonymousCheckboxVisible = true,
             )
         }
     }
@@ -475,7 +473,6 @@ private fun initPokeFriendView(
                 viewModel = viewModel,
                 userId = pokeFriendItem.userId,
                 pokeMessageType = PokeMessageType.POKE_FRIEND,
-                isAnonymousCheckboxVisible = isAnonymousCheckboxVisible(pokeFriendItem.pokeNum),
             )
         }
     }
@@ -487,12 +484,10 @@ private fun showMessageListBottomSheet(
     userId: Int,
     pokeMessageType: PokeMessageType,
     isFirstMeet: Boolean = false,
-    isAnonymousCheckboxVisible: Boolean = true,
 ) {
     val messageListBottomSheet =
         MessageListBottomSheetFragment.Builder()
             .setMessageListType(pokeMessageType)
-            .setAnonymousCheckboxVisible(isAnonymousCheckboxVisible)
             .onClickMessageListItem { message, isAnonymous ->
                 viewModel.pokeUser(
                     userId = userId,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/main/PokeScreen.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/main/PokeScreen.kt
@@ -64,6 +64,7 @@ import org.sopt.official.feature.poke.message.MessageListBottomSheetFragment
 import org.sopt.official.feature.poke.user.PokeUserListClickListener
 import org.sopt.official.feature.poke.util.addOnAnimationEndListener
 import org.sopt.official.feature.poke.util.dismissBottomSheet
+import org.sopt.official.feature.poke.util.isAnonymousVisible
 import org.sopt.official.feature.poke.util.isBestFriend
 import org.sopt.official.feature.poke.util.isSoulMate
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
@@ -349,10 +350,11 @@ private fun initPokeMeView(
     viewModel: PokeMainViewModel
 ) {
     val context = binding.root.context
+    val isAnonymousVisible = isAnonymousVisible(pokeMeItem.isAnonymous, pokeMeItem.relationName)
     with(binding) {
         layoutSomeonePokeMe.setVisible(true)
         imgUserProfileSomeonePokeMe.setOnClickListener {
-            if (pokeMeItem.isAnonymous) return@setOnClickListener
+            if (isAnonymousVisible) return@setOnClickListener
             tracker.track(
                 type = EventType.CLICK,
                 name = "memberprofile",
@@ -365,7 +367,7 @@ private fun initPokeMeView(
             context.startActivity(Intent(Intent.ACTION_VIEW, context.getString(R.string.poke_user_profile_url, pokeMeItem.userId).toUri()))
         }
 
-        if (pokeMeItem.isAnonymous) {
+        if (isAnonymousVisible) {
             imgUserProfileSomeonePokeMe.load(R.drawable.image_anonymous_profile) { transformations(CircleCropTransformation()) }
             tvUserNameSomeonePokeMe.text = pokeMeItem.anonymousName
             tvFriendsStatusSomeonePokeMe.visibility = View.GONE
@@ -421,9 +423,10 @@ private fun initPokeFriendView(
     viewModel: PokeMainViewModel
 ) {
     val context = binding.root.context
+    val isAnonymousVisible = isAnonymousVisible(pokeFriendItem.isAnonymous, pokeFriendItem.relationName)
     with(binding) {
         imgUserProfilePokeMyFriend.setOnClickListener {
-            if (pokeFriendItem.isAnonymous) return@setOnClickListener
+            if (isAnonymousVisible) return@setOnClickListener
 
             tracker.track(
                 type = EventType.CLICK,
@@ -443,7 +446,7 @@ private fun initPokeFriendView(
             )
         }
 
-        if (pokeFriendItem.isAnonymous) {
+        if (isAnonymousVisible) {
             imgUserProfilePokeMyFriend.load(R.drawable.image_anonymous_profile) { transformations(CircleCropTransformation()) }
             tvUserNamePokeMyFriend.text = pokeFriendItem.anonymousName
         } else {

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/message/MessageListBottomSheetFragment.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/message/MessageListBottomSheetFragment.kt
@@ -50,6 +50,7 @@ class MessageListBottomSheetFragment : BottomSheetDialogFragment() {
 
     var pokeMessageType: PokeMessageType? = null
     var onClickMessageListItem: ((message: String, isAnonymous: Boolean) -> Unit)? = null
+    var isAnonymousCheckboxLocked: Boolean = false
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         viewModel = ViewModelProvider(this)[MessageListBottomSheetViewModel::class.java]
@@ -85,8 +86,15 @@ class MessageListBottomSheetFragment : BottomSheetDialogFragment() {
     }
 
     private fun initCheckbox() {
+        viewModel.setPokeAnonymousCheckboxChecked(!isAnonymousCheckboxLocked)
+
         binding.checkBoxAnonymous.setOnClickListener {
-            viewModel.setPokeAnonymousCheckboxClicked()
+            if (isAnonymousCheckboxLocked) {
+                binding.checkBoxAnonymous.isChecked = false
+                showPokeToast(getString(R.string.toast_poke_soulmate_realname_only))
+            } else {
+                viewModel.setPokeAnonymousCheckboxClicked()
+            }
         }
 
         viewModel.pokeAnonymousCheckboxChecked.flowWithLifecycle(lifecycle).onEach { isChecked ->
@@ -100,7 +108,7 @@ class MessageListBottomSheetFragment : BottomSheetDialogFragment() {
 
     private val messageListItemClickListener =
         MessageItemClickListener { message ->
-            val isAnonymous = viewModel.pokeAnonymousCheckboxChecked.value
+            val isAnonymous = if (isAnonymousCheckboxLocked) false else viewModel.pokeAnonymousCheckboxChecked.value
             onClickMessageListItem?.let { it(message, isAnonymous) }
         }
 
@@ -116,6 +124,11 @@ class MessageListBottomSheetFragment : BottomSheetDialogFragment() {
 
         fun onClickMessageListItem(event: (message: String, isAnonymous: Boolean) -> Unit): Builder {
             bottomSheet.onClickMessageListItem = event
+            return this
+        }
+
+        fun setAnonymousCheckboxLocked(isLocked: Boolean): Builder {
+            bottomSheet.isAnonymousCheckboxLocked = isLocked
             return this
         }
     }

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/message/MessageListBottomSheetFragment.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/message/MessageListBottomSheetFragment.kt
@@ -35,7 +35,6 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import org.sopt.official.common.util.ui.setVisible
 import org.sopt.official.common.util.viewBinding
 import org.sopt.official.domain.poke.entity.PokeMessageList
 import org.sopt.official.domain.poke.type.PokeMessageType
@@ -51,7 +50,6 @@ class MessageListBottomSheetFragment : BottomSheetDialogFragment() {
 
     var pokeMessageType: PokeMessageType? = null
     var onClickMessageListItem: ((message: String, isAnonymous: Boolean) -> Unit)? = null
-    var isAnonymousCheckboxVisible: Boolean = true
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         viewModel = ViewModelProvider(this)[MessageListBottomSheetViewModel::class.java]
@@ -87,9 +85,6 @@ class MessageListBottomSheetFragment : BottomSheetDialogFragment() {
     }
 
     private fun initCheckbox() {
-        binding.checkBoxAnonymous.setVisible(isAnonymousCheckboxVisible)
-        binding.textViewAnonymous.setVisible(isAnonymousCheckboxVisible)
-
         binding.checkBoxAnonymous.setOnClickListener {
             viewModel.setPokeAnonymousCheckboxClicked()
         }
@@ -105,7 +100,7 @@ class MessageListBottomSheetFragment : BottomSheetDialogFragment() {
 
     private val messageListItemClickListener =
         MessageItemClickListener { message ->
-            val isAnonymous = if (isAnonymousCheckboxVisible) viewModel.pokeAnonymousCheckboxChecked.value else false
+            val isAnonymous = viewModel.pokeAnonymousCheckboxChecked.value
             onClickMessageListItem?.let { it(message, isAnonymous) }
         }
 
@@ -121,11 +116,6 @@ class MessageListBottomSheetFragment : BottomSheetDialogFragment() {
 
         fun onClickMessageListItem(event: (message: String, isAnonymous: Boolean) -> Unit): Builder {
             bottomSheet.onClickMessageListItem = event
-            return this
-        }
-
-        fun setAnonymousCheckboxVisible(isVisible: Boolean): Builder {
-            bottomSheet.isAnonymousCheckboxVisible = isVisible
             return this
         }
     }

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/message/MessageListBottomSheetFragment.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/message/MessageListBottomSheetFragment.kt
@@ -35,6 +35,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import org.sopt.official.common.util.ui.setVisible
 import org.sopt.official.common.util.viewBinding
 import org.sopt.official.domain.poke.entity.PokeMessageList
 import org.sopt.official.domain.poke.type.PokeMessageType
@@ -50,6 +51,7 @@ class MessageListBottomSheetFragment : BottomSheetDialogFragment() {
 
     var pokeMessageType: PokeMessageType? = null
     var onClickMessageListItem: ((message: String, isAnonymous: Boolean) -> Unit)? = null
+    var isAnonymousCheckboxVisible: Boolean = true
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         viewModel = ViewModelProvider(this)[MessageListBottomSheetViewModel::class.java]
@@ -85,6 +87,9 @@ class MessageListBottomSheetFragment : BottomSheetDialogFragment() {
     }
 
     private fun initCheckbox() {
+        binding.checkBoxAnonymous.setVisible(isAnonymousCheckboxVisible)
+        binding.textViewAnonymous.setVisible(isAnonymousCheckboxVisible)
+
         binding.checkBoxAnonymous.setOnClickListener {
             viewModel.setPokeAnonymousCheckboxClicked()
         }
@@ -100,7 +105,8 @@ class MessageListBottomSheetFragment : BottomSheetDialogFragment() {
 
     private val messageListItemClickListener =
         MessageItemClickListener { message ->
-            onClickMessageListItem?.let { it(message, viewModel.pokeAnonymousCheckboxChecked.value) }
+            val isAnonymous = if (isAnonymousCheckboxVisible) viewModel.pokeAnonymousCheckboxChecked.value else false
+            onClickMessageListItem?.let { it(message, isAnonymous) }
         }
 
     class Builder {
@@ -115,6 +121,11 @@ class MessageListBottomSheetFragment : BottomSheetDialogFragment() {
 
         fun onClickMessageListItem(event: (message: String, isAnonymous: Boolean) -> Unit): Builder {
             bottomSheet.onClickMessageListItem = event
+            return this
+        }
+
+        fun setAnonymousCheckboxVisible(isVisible: Boolean): Builder {
+            bottomSheet.isAnonymousCheckboxVisible = isVisible
             return this
         }
     }

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/message/MessageListBottomSheetViewModel.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/message/MessageListBottomSheetViewModel.kt
@@ -79,4 +79,8 @@ class MessageListBottomSheetViewModel @Inject constructor(
             }
         }
     }
+
+    fun setPokeAnonymousCheckboxChecked(isChecked: Boolean) {
+        _pokeAnonymousCheckboxChecked.value = isChecked
+    }
 }

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/message/MessageListBottomSheetViewModel.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/message/MessageListBottomSheetViewModel.kt
@@ -50,7 +50,6 @@ class MessageListBottomSheetViewModel @Inject constructor(
     private val _pokeAnonymousCheckboxChecked = MutableStateFlow(true)
     val pokeAnonymousCheckboxChecked: StateFlow<Boolean>
         get() = _pokeAnonymousCheckboxChecked
-
     val pokeAnonymousOffToast = MutableSharedFlow<Unit>()
 
     fun getPokeMessageList(pokeMessageType: PokeMessageType) {

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/notification/PokeNotificationAdapter.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/notification/PokeNotificationAdapter.kt
@@ -37,7 +37,6 @@ import org.sopt.official.domain.poke.entity.PokeUser
 import org.sopt.official.feature.poke.R
 import org.sopt.official.feature.poke.databinding.ItemPokeNotificationBinding
 import org.sopt.official.feature.poke.user.PokeUserListClickListener
-import org.sopt.official.feature.poke.util.isAnonymousVisible
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
 
 class PokeNotificationAdapter(
@@ -58,7 +57,7 @@ class PokeNotificationAdapter(
             val user = currentList[position]
 
             itemView.findViewById<ImageView>(R.id.img_user_profile).setOnClickListener {
-                if (isAnonymousVisible(user.isAnonymous, user.relationName)) return@setOnClickListener
+                if (user.isAnonymous) return@setOnClickListener
                 clickListener.onClickProfileImage(user.userId)
             }
 
@@ -89,7 +88,7 @@ class PokeNotificationAdapter(
     ) : RecyclerView.ViewHolder(viewBinding.root) {
         fun onBind(item: PokeUser) {
             with(viewBinding) {
-                if (isAnonymousVisible(item.isAnonymous, item.relationName)) {
+                if (item.isAnonymous) {
                     imgUserProfile.load(R.drawable.image_anonymous_profile) { transformations(CircleCropTransformation()) }
                     tvUserName.text = item.anonymousName
                     tvUserGeneration.visibility = View.GONE

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/notification/PokeNotificationAdapter.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/notification/PokeNotificationAdapter.kt
@@ -37,6 +37,7 @@ import org.sopt.official.domain.poke.entity.PokeUser
 import org.sopt.official.feature.poke.R
 import org.sopt.official.feature.poke.databinding.ItemPokeNotificationBinding
 import org.sopt.official.feature.poke.user.PokeUserListClickListener
+import org.sopt.official.feature.poke.util.isAnonymousVisible
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
 
 class PokeNotificationAdapter(
@@ -54,15 +55,16 @@ class PokeNotificationAdapter(
     override fun onBindViewHolder(holder: NotificationListViewHolder, position: Int) {
         holder.apply {
             onBind(currentList[position])
+            val user = currentList[position]
 
             itemView.findViewById<ImageView>(R.id.img_user_profile).setOnClickListener {
-                if (currentList[position].isAnonymous) return@setOnClickListener
-                clickListener.onClickProfileImage(currentList[position].userId)
+                if (isAnonymousVisible(user.isAnonymous, user.relationName)) return@setOnClickListener
+                clickListener.onClickProfileImage(user.userId)
             }
 
             itemView.findViewById<ImageView>(R.id.img_poke).setOnClickListener {
-                if (currentList[position].isAlreadyPoke) return@setOnClickListener
-                clickListener.onClickPokeButton(currentList[position])
+                if (user.isAlreadyPoke) return@setOnClickListener
+                clickListener.onClickPokeButton(user)
             }
         }
     }
@@ -87,7 +89,7 @@ class PokeNotificationAdapter(
     ) : RecyclerView.ViewHolder(viewBinding.root) {
         fun onBind(item: PokeUser) {
             with(viewBinding) {
-                if (item.isAnonymous) {
+                if (isAnonymousVisible(item.isAnonymous, item.relationName)) {
                     imgUserProfile.load(R.drawable.image_anonymous_profile) { transformations(CircleCropTransformation()) }
                     tvUserName.text = item.anonymousName
                     tvUserGeneration.visibility = View.GONE

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/notification/PokeNotificationScreen.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/notification/PokeNotificationScreen.kt
@@ -64,6 +64,7 @@ import org.sopt.official.feature.poke.message.MessageListBottomSheetFragment
 import org.sopt.official.feature.poke.user.PokeUserListClickListener
 import org.sopt.official.feature.poke.util.addOnAnimationEndListener
 import org.sopt.official.feature.poke.util.dismissBottomSheet
+import org.sopt.official.feature.poke.util.isAnonymousCheckboxLocked
 import org.sopt.official.feature.poke.util.isBestFriend
 import org.sopt.official.feature.poke.util.isSoulMate
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
@@ -119,6 +120,7 @@ fun PokeNotificationScreen(
                 if (fragmentActivity != null && fragmentManager != null) {
                     val bottomSheet = MessageListBottomSheetFragment.Builder()
                         .setMessageListType(messageType)
+                        .setAnonymousCheckboxLocked(isLocked = isAnonymousCheckboxLocked(user.pokeNum))
                         .onClickMessageListItem { message, isAnonymous ->
                             viewModel.pokeUser(
                                 userId = user.userId,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/notification/PokeNotificationScreen.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/notification/PokeNotificationScreen.kt
@@ -181,7 +181,7 @@ fun PokeNotificationScreen(
                         }
                     } else {
                         val isBestFriend = isBestFriend(user.pokeNum, user.isAnonymous)
-                        val isSoulMate = isSoulMate(user.pokeNum, user.isAnonymous)
+                        val isSoulMate = isSoulMate(user.pokeNum)
 
                         if (!isBestFriend && !isSoulMate) {
                             if (!state.isFirstMeet) {

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/user/PokeUserListAdapter.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/user/PokeUserListAdapter.kt
@@ -34,7 +34,6 @@ import org.sopt.official.domain.poke.entity.PokeUser
 import org.sopt.official.feature.poke.R
 import org.sopt.official.feature.poke.databinding.ItemPokeUserLargeBinding
 import org.sopt.official.feature.poke.databinding.ItemPokeUserSmallBinding
-import org.sopt.official.feature.poke.util.isAnonymousVisible
 
 class PokeUserListAdapter(
     private val pokeUserListItemViewType: PokeUserListItemViewType,
@@ -65,11 +64,10 @@ class PokeUserListAdapter(
 
     override fun onBindViewHolder(holder: PokeUserViewHolder, position: Int) {
         val user = currentList[position]
-        val isAnonymousVisible = isAnonymousVisible(user.isAnonymous, user.relationName)
         holder.apply {
             onBind(user)
             itemView.findViewById<ImageView>(R.id.imageView_profile).setOnClickListener {
-                if (isAnonymousVisible) return@setOnClickListener
+                if (user.isAnonymous) return@setOnClickListener
                 clickListener.onClickProfileImage(user.userId)
             }
             itemView.findViewById<ImageButton>(R.id.imageButton_poke).setOnClickListener {

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/user/PokeUserListAdapter.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/user/PokeUserListAdapter.kt
@@ -34,6 +34,7 @@ import org.sopt.official.domain.poke.entity.PokeUser
 import org.sopt.official.feature.poke.R
 import org.sopt.official.feature.poke.databinding.ItemPokeUserLargeBinding
 import org.sopt.official.feature.poke.databinding.ItemPokeUserSmallBinding
+import org.sopt.official.feature.poke.util.isAnonymousVisible
 
 class PokeUserListAdapter(
     private val pokeUserListItemViewType: PokeUserListItemViewType,
@@ -67,7 +68,7 @@ class PokeUserListAdapter(
         holder.apply {
             onBind(user)
             itemView.findViewById<ImageView>(R.id.imageView_profile).setOnClickListener {
-                if (user.isAnonymous) return@setOnClickListener
+                if (isAnonymousVisible(user.isAnonymous, user.relationName, user.pokeNum)) return@setOnClickListener
                 clickListener.onClickProfileImage(user.userId)
             }
             itemView.findViewById<ImageButton>(R.id.imageButton_poke).setOnClickListener {

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/user/PokeUserListAdapter.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/user/PokeUserListAdapter.kt
@@ -34,6 +34,7 @@ import org.sopt.official.domain.poke.entity.PokeUser
 import org.sopt.official.feature.poke.R
 import org.sopt.official.feature.poke.databinding.ItemPokeUserLargeBinding
 import org.sopt.official.feature.poke.databinding.ItemPokeUserSmallBinding
+import org.sopt.official.feature.poke.util.isAnonymousVisible
 
 class PokeUserListAdapter(
     private val pokeUserListItemViewType: PokeUserListItemViewType,
@@ -63,15 +64,17 @@ class PokeUserListAdapter(
     }
 
     override fun onBindViewHolder(holder: PokeUserViewHolder, position: Int) {
+        val user = currentList[position]
+        val isAnonymousVisible = isAnonymousVisible(user.isAnonymous, user.relationName)
         holder.apply {
-            onBind(currentList[position])
+            onBind(user)
             itemView.findViewById<ImageView>(R.id.imageView_profile).setOnClickListener {
-                if (currentList[position].isAnonymous) return@setOnClickListener
-                clickListener.onClickProfileImage(currentList[position].userId)
+                if (isAnonymousVisible) return@setOnClickListener
+                clickListener.onClickProfileImage(user.userId)
             }
             itemView.findViewById<ImageButton>(R.id.imageButton_poke).setOnClickListener {
-                if (currentList[position].isAlreadyPoke) return@setOnClickListener
-                clickListener.onClickPokeButton(currentList[position])
+                if (user.isAlreadyPoke) return@setOnClickListener
+                clickListener.onClickPokeButton(user)
             }
         }
     }

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/user/PokeUserViewHolder.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/user/PokeUserViewHolder.kt
@@ -33,6 +33,7 @@ import org.sopt.official.domain.poke.entity.PokeUser
 import org.sopt.official.feature.poke.R
 import org.sopt.official.feature.poke.databinding.ItemPokeUserLargeBinding
 import org.sopt.official.feature.poke.databinding.ItemPokeUserSmallBinding
+import org.sopt.official.feature.poke.util.isAnonymousVisible
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
 
 sealed class PokeUserViewHolder(
@@ -44,9 +45,10 @@ sealed class PokeUserViewHolder(
         private val binding: ItemPokeUserSmallBinding,
     ) : PokeUserViewHolder(binding) {
         override fun onBind(pokeUser: PokeUser) {
+            val isAnonymousVisible = isAnonymousVisible(pokeUser.isAnonymous, pokeUser.relationName)
             binding.apply {
                 imageViewFriendRelationOutline.setRelationStrokeColor(pokeUser.relationName)
-                if (pokeUser.isAnonymous) {
+                if (isAnonymousVisible) {
                     imageViewProfile.load(R.drawable.image_anonymous_profile) {
                         crossfade(true)
                         transformations(CircleCropTransformation())
@@ -73,9 +75,10 @@ sealed class PokeUserViewHolder(
         private val binding: ItemPokeUserLargeBinding,
     ) : PokeUserViewHolder(binding) {
         override fun onBind(pokeUser: PokeUser) {
+            val isAnonymousVisible = isAnonymousVisible(pokeUser.isAnonymous, pokeUser.relationName)
             binding.apply {
                 when {
-                    pokeUser.isAnonymous ->
+                    isAnonymousVisible ->
                         imageViewProfile.load(R.drawable.image_anonymous_profile) {
                             crossfade(true)
                             transformations(CircleCropTransformation())
@@ -93,8 +96,8 @@ sealed class PokeUserViewHolder(
                             transformations(CircleCropTransformation())
                         }
                 }
-                textViewUserName.text = if (pokeUser.isAnonymous) pokeUser.anonymousName else pokeUser.name
-                textViewUserInfo.isVisible = !pokeUser.isAnonymous
+                textViewUserName.text = if (isAnonymousVisible) pokeUser.anonymousName else pokeUser.name
+                textViewUserInfo.isVisible = !isAnonymousVisible
                 textViewUserInfo.text = binding.root.context.getString(R.string.poke_user_info, pokeUser.generation, pokeUser.part)
                 imageButtonPoke.isEnabled = !pokeUser.isAlreadyPoke
             }

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/user/PokeUserViewHolder.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/user/PokeUserViewHolder.kt
@@ -33,6 +33,7 @@ import org.sopt.official.domain.poke.entity.PokeUser
 import org.sopt.official.feature.poke.R
 import org.sopt.official.feature.poke.databinding.ItemPokeUserLargeBinding
 import org.sopt.official.feature.poke.databinding.ItemPokeUserSmallBinding
+import org.sopt.official.feature.poke.util.isAnonymousVisible
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
 
 sealed class PokeUserViewHolder(
@@ -44,9 +45,14 @@ sealed class PokeUserViewHolder(
         private val binding: ItemPokeUserSmallBinding,
     ) : PokeUserViewHolder(binding) {
         override fun onBind(pokeUser: PokeUser) {
+            val isAnonymousVisible = isAnonymousVisible(
+                isAnonymous = pokeUser.isAnonymous,
+                relationName = pokeUser.relationName,
+                pokeNum = pokeUser.pokeNum,
+            )
             binding.apply {
                 imageViewFriendRelationOutline.setRelationStrokeColor(pokeUser.relationName)
-                if (pokeUser.isAnonymous) {
+                if (isAnonymousVisible) {
                     imageViewProfile.load(R.drawable.image_anonymous_profile) {
                         crossfade(true)
                         transformations(CircleCropTransformation())
@@ -73,7 +79,11 @@ sealed class PokeUserViewHolder(
         private val binding: ItemPokeUserLargeBinding,
     ) : PokeUserViewHolder(binding) {
         override fun onBind(pokeUser: PokeUser) {
-            val isAnonymousVisible = pokeUser.isAnonymous
+            val isAnonymousVisible = isAnonymousVisible(
+                isAnonymous = pokeUser.isAnonymous,
+                relationName = pokeUser.relationName,
+                pokeNum = pokeUser.pokeNum,
+            )
             binding.apply {
                 when {
                     isAnonymousVisible ->

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/user/PokeUserViewHolder.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/user/PokeUserViewHolder.kt
@@ -33,7 +33,6 @@ import org.sopt.official.domain.poke.entity.PokeUser
 import org.sopt.official.feature.poke.R
 import org.sopt.official.feature.poke.databinding.ItemPokeUserLargeBinding
 import org.sopt.official.feature.poke.databinding.ItemPokeUserSmallBinding
-import org.sopt.official.feature.poke.util.isAnonymousVisible
 import org.sopt.official.feature.poke.util.setRelationStrokeColor
 
 sealed class PokeUserViewHolder(
@@ -45,10 +44,9 @@ sealed class PokeUserViewHolder(
         private val binding: ItemPokeUserSmallBinding,
     ) : PokeUserViewHolder(binding) {
         override fun onBind(pokeUser: PokeUser) {
-            val isAnonymousVisible = isAnonymousVisible(pokeUser.isAnonymous, pokeUser.relationName)
             binding.apply {
                 imageViewFriendRelationOutline.setRelationStrokeColor(pokeUser.relationName)
-                if (isAnonymousVisible) {
+                if (pokeUser.isAnonymous) {
                     imageViewProfile.load(R.drawable.image_anonymous_profile) {
                         crossfade(true)
                         transformations(CircleCropTransformation())
@@ -75,7 +73,7 @@ sealed class PokeUserViewHolder(
         private val binding: ItemPokeUserLargeBinding,
     ) : PokeUserViewHolder(binding) {
         override fun onBind(pokeUser: PokeUser) {
-            val isAnonymousVisible = isAnonymousVisible(pokeUser.isAnonymous, pokeUser.relationName)
+            val isAnonymousVisible = pokeUser.isAnonymous
             binding.apply {
                 when {
                     isAnonymousVisible ->

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/util/PokeUtil.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/util/PokeUtil.kt
@@ -109,7 +109,7 @@ private val bestFriendRange = 5..6
 private val soulMateRange = 11..12
 
 fun isBestFriend(pokeNum: Int, isAnonymous: Boolean) = pokeNum in bestFriendRange && isAnonymous
-fun isSoulMate(pokeNum: Int, isAnonymous: Boolean) = pokeNum in soulMateRange && isAnonymous
+fun isSoulMate(pokeNum: Int) = pokeNum in soulMateRange
 
 fun dismissBottomSheet(
     fragmentManager: FragmentManager?,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/util/PokeUtil.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/util/PokeUtil.kt
@@ -111,6 +111,8 @@ private const val soulMateMinPokeCount = 10
 
 fun isBestFriend(pokeNum: Int, isAnonymous: Boolean) = pokeNum in bestFriendRange && isAnonymous
 fun isSoulMate(pokeNum: Int) = pokeNum in soulMateRange
+fun isAnonymousVisible(isAnonymous: Boolean, relationName: String): Boolean =
+    isAnonymous && relationName != PokeFriendType.SOULMATE.readableName
 fun isAnonymousCheckboxVisible(pokeNum: Int): Boolean = pokeNum < soulMateMinPokeCount
 
 fun dismissBottomSheet(

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/util/PokeUtil.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/util/PokeUtil.kt
@@ -107,9 +107,11 @@ fun Fragment.showPokeToast(message: String) {
 
 private val bestFriendRange = 5..6
 private val soulMateRange = 11..12
+private const val soulMateMinPokeCount = 10
 
 fun isBestFriend(pokeNum: Int, isAnonymous: Boolean) = pokeNum in bestFriendRange && isAnonymous
 fun isSoulMate(pokeNum: Int) = pokeNum in soulMateRange
+fun isAnonymousCheckboxVisible(pokeNum: Int): Boolean = pokeNum < soulMateMinPokeCount
 
 fun dismissBottomSheet(
     fragmentManager: FragmentManager?,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/util/PokeUtil.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/util/PokeUtil.kt
@@ -109,8 +109,6 @@ private val bestFriendRange = 5..6
 private val soulMateRange = 11..12
 fun isBestFriend(pokeNum: Int, isAnonymous: Boolean) = pokeNum in bestFriendRange && isAnonymous
 fun isSoulMate(pokeNum: Int) = pokeNum in soulMateRange
-fun isAnonymousVisible(isAnonymous: Boolean, relationName: String): Boolean =
-    isAnonymous && relationName != PokeFriendType.SOULMATE.readableName
 
 fun dismissBottomSheet(
     fragmentManager: FragmentManager?,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/util/PokeUtil.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/util/PokeUtil.kt
@@ -107,8 +107,10 @@ fun Fragment.showPokeToast(message: String) {
 
 private val bestFriendRange = 5..6
 private val soulMateRange = 11..12
+private const val soulMateMinPokeCount = 10
 fun isBestFriend(pokeNum: Int, isAnonymous: Boolean) = pokeNum in bestFriendRange && isAnonymous
 fun isSoulMate(pokeNum: Int) = pokeNum in soulMateRange
+fun isAnonymousCheckboxLocked(pokeNum: Int): Boolean = pokeNum >= soulMateMinPokeCount
 
 fun dismissBottomSheet(
     fragmentManager: FragmentManager?,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/util/PokeUtil.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/util/PokeUtil.kt
@@ -107,13 +107,10 @@ fun Fragment.showPokeToast(message: String) {
 
 private val bestFriendRange = 5..6
 private val soulMateRange = 11..12
-private const val soulMateMinPokeCount = 10
-
 fun isBestFriend(pokeNum: Int, isAnonymous: Boolean) = pokeNum in bestFriendRange && isAnonymous
 fun isSoulMate(pokeNum: Int) = pokeNum in soulMateRange
 fun isAnonymousVisible(isAnonymous: Boolean, relationName: String): Boolean =
     isAnonymous && relationName != PokeFriendType.SOULMATE.readableName
-fun isAnonymousCheckboxVisible(pokeNum: Int): Boolean = pokeNum < soulMateMinPokeCount
 
 fun dismissBottomSheet(
     fragmentManager: FragmentManager?,

--- a/feature/poke/src/main/java/org/sopt/official/feature/poke/util/PokeUtil.kt
+++ b/feature/poke/src/main/java/org/sopt/official/feature/poke/util/PokeUtil.kt
@@ -111,6 +111,8 @@ private const val soulMateMinPokeCount = 10
 fun isBestFriend(pokeNum: Int, isAnonymous: Boolean) = pokeNum in bestFriendRange && isAnonymous
 fun isSoulMate(pokeNum: Int) = pokeNum in soulMateRange
 fun isAnonymousCheckboxLocked(pokeNum: Int): Boolean = pokeNum >= soulMateMinPokeCount
+fun isAnonymousVisible(isAnonymous: Boolean, relationName: String, pokeNum: Int): Boolean =
+    isAnonymous && !(relationName == PokeFriendType.SOULMATE.readableName && pokeNum == 11)
 
 fun dismissBottomSheet(
     fragmentManager: FragmentManager?,

--- a/feature/poke/src/main/res/values/strings.xml
+++ b/feature/poke/src/main/res/values/strings.xml
@@ -83,5 +83,4 @@
     <string name="toast_poke_error">문제가 발생했습니다.</string>
     <string name="toast_poke_user_success">콕 찌르기를 완료했어요.</string>
     <string name="toast_poke_anonymous_off">익명 해제 시, 상대방이 나를 알 수 있어요.</string>
-
 </resources>

--- a/feature/poke/src/main/res/values/strings.xml
+++ b/feature/poke/src/main/res/values/strings.xml
@@ -83,4 +83,5 @@
     <string name="toast_poke_error">문제가 발생했습니다.</string>
     <string name="toast_poke_user_success">콕 찌르기를 완료했어요.</string>
     <string name="toast_poke_anonymous_off">익명 해제 시, 상대방이 나를 알 수 있어요.</string>
+    <string name="toast_poke_soulmate_realname_only">천생연분은 실명으로만 콕찌를 수 있어요.</string>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #1577

## Work Description ✏️
- 천생연분일때 익명 실명 관계없이 애니메이션 뜨도록 수정
- 10번째 콕 이상인 경우, 콕찌르기 시 체크박스 해제 강제 유지 및 체크박스 클릭시 실명으로만 찌를 수 있다는 토스트 메시지를 띄움.
- 10번째 콕 이상인 경우, 실명으로만 콕찌르기
- 10콕 → 11콕 전환 시, 천생연분이 되었어도 내가 보이는 상대 프로필은 익명으로 보일 수 있음 이슈
   -> 11번째 콕에서만 익명 여부를 무시하고 실명으로 표시되도록 수정

## Screenshot 📸
<<최종 버전>>

https://github.com/user-attachments/assets/26e7fb22-d55b-42a6-939d-0947fc1d19ee




## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
활성화된 콕찌르기를 다써서 영상에는 10번째 콕인경우에대한 부분과 애니메이션 처리에 대한 시연은 없는데,,
한번씩은 다 해보았습니다..! 혹시 이상있는경우 알려주시면 감사하겠습니다 ~

++ 추가로 논의된 부분도 작업했어요.
회의때 이야기한것처럼 기존에 프로필이 다보이는 것 보다는 앞으로 콕찌르기를 할때
실명으로 찌르게 하면 마이그레이션이 더 자연스러울 거라 생각해서 프로필이 다보이게 하지 않고 API 를 실명으로 찌르게 변경했습니다.