### PR TITLE
[Mod/#1582] 앱잼탬프 qa 전 수정사항 반영

### DIFF
--- a/domain/home/build.gradle.kts
+++ b/domain/home/build.gradle.kts
@@ -32,4 +32,5 @@ kotlin {
 
 dependencies {
     implementation(libs.javax.inject)
+    implementation(libs.kotlin.coroutines)
 }

--- a/domain/home/src/main/java/org/sopt/official/domain/home/AppServiceManager.kt
+++ b/domain/home/src/main/java/org/sopt/official/domain/home/AppServiceManager.kt
@@ -23,8 +23,5 @@ class AppServiceManager @Inject constructor(
         
         getAppServiceUseCase()
             .onSuccess { _appServices.value = it }
-            .onFailure {
-                _appServices.value = emptyList()
-            }
     }
 }

--- a/domain/home/src/main/java/org/sopt/official/domain/home/AppServiceManager.kt
+++ b/domain/home/src/main/java/org/sopt/official/domain/home/AppServiceManager.kt
@@ -1,0 +1,30 @@
+package org.sopt.official.domain.home
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.sopt.official.domain.home.model.AppService
+import org.sopt.official.domain.home.usecase.GetAppServiceUseCase
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * AppServiceManager: app-service 관리 클래스
+ * */
+@Singleton
+class AppServiceManager @Inject constructor(
+    private val getAppServiceUseCase: GetAppServiceUseCase
+) {
+    private val _appServices = MutableStateFlow<List<AppService>?>(null)
+    val appServices: StateFlow<List<AppService>?> = _appServices.asStateFlow()
+
+    suspend fun fetchAppServices(forceUpdate: Boolean = false) {
+        if (!forceUpdate && _appServices.value != null) return
+        
+        getAppServiceUseCase()
+            .onSuccess { _appServices.value = it }
+            .onFailure {
+                _appServices.value = emptyList()
+            }
+    }
+}

--- a/domain/soptlog/src/main/java/org/sopt/official/domain/soptlog/model/SoptLogInfo.kt
+++ b/domain/soptlog/src/main/java/org/sopt/official/domain/soptlog/model/SoptLogInfo.kt
@@ -25,7 +25,7 @@
 package org.sopt.official.domain.soptlog.model
 
 data class SoptLogInfo(
-    val isActive: Boolean,
+    val isActive: Boolean = false,
     val isFortuneChecked: Boolean,
     val todayFortuneText: String,
     val soptampCount: Int? = null,

--- a/feature/appjamtamp/src/main/java/org/sopt/official/feature/appjamtamp/missionlist/component/AppjamtampFloatingButton.kt
+++ b/feature/appjamtamp/src/main/java/org/sopt/official/feature/appjamtamp/missionlist/component/AppjamtampFloatingButton.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import org.sopt.official.designsystem.Black
 import org.sopt.official.designsystem.Gray950
 import org.sopt.official.designsystem.SoptTheme
 import org.sopt.official.designsystem.White

--- a/feature/appjamtamp/src/main/java/org/sopt/official/feature/appjamtamp/missionlist/component/AppjamtampFloatingButton.kt
+++ b/feature/appjamtamp/src/main/java/org/sopt/official/feature/appjamtamp/missionlist/component/AppjamtampFloatingButton.kt
@@ -85,7 +85,7 @@ private fun AppjamtampFloatingBody() {
         )
 
         Text(
-            text = "앱잼팀 랭킹",
+            text = "앱잼팀 현황",
             style = SoptTheme.typography.heading18B,
             color = Gray950
         )

--- a/feature/appjamtamp/src/main/java/org/sopt/official/feature/appjamtamp/ranking/AppjamtampRankingScreen.kt
+++ b/feature/appjamtamp/src/main/java/org/sopt/official/feature/appjamtamp/ranking/AppjamtampRankingScreen.kt
@@ -130,7 +130,7 @@ internal fun AppjamtampRankingScreen(
             .navigationBarsPadding(),
         topBar = {
             BackButtonHeader(
-                title = "앱잼팀 랭킹",
+                title = "앱잼팀 현황",
                 onBackButtonClick = onBackButtonClick,
                 modifier = Modifier
                     .padding(vertical = 12.dp)
@@ -153,7 +153,7 @@ internal fun AppjamtampRankingScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = "따끈따끈 합숙미션 구경하기",
+                    text = "따끈따끈 지금 앱잼팀은?",
                     color = White,
                     style = SoptTheme.typography.heading20B
                 )
@@ -207,7 +207,7 @@ internal fun AppjamtampRankingScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = "오늘의 득점 랭킹",
+                    text = "오늘의 미션 달성 보드",
                     color = White,
                     style = SoptTheme.typography.heading20B
                 )
@@ -225,7 +225,7 @@ internal fun AppjamtampRankingScreen(
             Spacer(modifier = Modifier.height(height = 8.dp))
 
             Text(
-                text = "미션을 인증해 오늘의 순위를 뒤집어보세요!",
+                text = "오늘 미션 인증하고 추가 점수를 획득해보세요!",
                 color = SoptTheme.colors.onSurface200,
                 style = SoptTheme.typography.body13M
             )
@@ -312,7 +312,7 @@ private fun AppjamtampRankingScreenPreview() {
                 ),
                 TopMissionScoreUiModel(
                     rank = 3,
-                    teamName = "비트",
+                    teamName = "키어로",
                     teamNumber = "FIRST",
                     todayPoints = 950,
                     totalPoints = 4200

--- a/feature/appjamtamp/src/main/java/org/sopt/official/feature/appjamtamp/ranking/component/TodayScoreRaking.kt
+++ b/feature/appjamtamp/src/main/java/org/sopt/official/feature/appjamtamp/ranking/component/TodayScoreRaking.kt
@@ -25,7 +25,6 @@
 package org.sopt.official.feature.appjamtamp.ranking.component
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -33,23 +32,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import org.sopt.official.common.util.noRippleClickable
 import org.sopt.official.designsystem.SoptTheme
 import org.sopt.official.designsystem.White
-import org.sopt.official.feature.appjamtamp.R
 import org.sopt.official.feature.appjamtamp.ranking.model.TopMissionScoreUiModel
-import org.sopt.official.common.util.noRippleClickable
 
 @Composable
 internal fun TodayScoreRaking(
@@ -57,19 +51,11 @@ internal fun TodayScoreRaking(
     modifier: Modifier = Modifier,
     onTeamRankingClick: (teamNumber: String) -> Unit = {}
 ) {
-    val rankIconRes = when (topMissionScore.rank) {
-        1 -> R.drawable.ic_rank_1
-        2 -> R.drawable.ic_rank_2
-        3 -> R.drawable.ic_rank_3
-        else -> R.drawable.ic_ranking_default
-    }
-    val rankTextColor = if (topMissionScore.rank <= 3) Color.White else SoptTheme.colors.onSurface100
-
     Column(
         modifier = modifier
             .clip(shape = RoundedCornerShape(size = 10.dp))
             .background(color = SoptTheme.colors.onSurface900)
-            .padding(start = 12.dp, end = 16.dp, top = 12.dp, bottom = 8.dp)
+            .padding(start = 12.dp, end = 16.dp, top = 12.dp, bottom = 12.dp)
             .noRippleClickable {
                 onTeamRankingClick(topMissionScore.teamNumber)
             }
@@ -80,31 +66,12 @@ internal fun TodayScoreRaking(
                 .align(Alignment.Start),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Box(
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(id = rankIconRes),
-                    contentDescription = null,
-                    tint = Color.Unspecified
-                )
-                Text(
-                    text = topMissionScore.rank.toString(),
-                    style = SoptTheme.typography.heading16B,
-                    color = rankTextColor,
-                    modifier = Modifier.padding(vertical = 2.dp, horizontal = 9.dp)
-                )
-            }
-
             Text(
                 text = topMissionScore.teamName,
                 color = White,
                 style = SoptTheme.typography.heading16B,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1,
-                modifier = Modifier
-                    .padding(vertical = 2.dp)
-                    .padding(start = 5.dp)
             )
         }
 
@@ -132,7 +99,7 @@ private fun TodayScoreRakingPreview() {
     SoptTheme {
         val mockTopMissionScoreUiModel = TopMissionScoreUiModel(
             rank = 2,
-            teamName = "노바",
+            teamName = "키어로",
             teamNumber = "FIRST",
             todayPoints = 1000,
             totalPoints = 3000

--- a/feature/home/src/main/java/org/sopt/official/feature/home/NewHomeViewModel.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/NewHomeViewModel.kt
@@ -35,12 +35,14 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import org.sopt.official.common.util.successOr
+import org.sopt.official.domain.home.AppServiceManager
 import org.sopt.official.domain.home.model.AppService
 import org.sopt.official.domain.home.model.FloatingToast
 import org.sopt.official.domain.home.model.RecentCalendar
@@ -68,17 +70,16 @@ import org.sopt.official.feature.home.model.HomeUiState.Unauthenticated
 import org.sopt.official.feature.home.model.HomeUserSoptLogDashboardModel
 import org.sopt.official.feature.home.model.Schedule
 import org.sopt.official.feature.home.model.defaultAppServices
+import org.sopt.official.localstorage.source.UserStorage
 import timber.log.Timber
 import javax.inject.Inject
-import org.sopt.official.domain.home.usecase.GetAppServiceUseCase
-import org.sopt.official.localstorage.source.UserStorage
 
 @HiltViewModel
 internal class NewHomeViewModel @Inject constructor(
     private val homeRepository: HomeRepository,
     private val checkNewInPokeUseCase: CheckNewInPokeUseCase,
     private val registerPushTokenUseCase: RegisterPushTokenUseCase,
-    private val getAppServiceUseCase: GetAppServiceUseCase,
+    private val appServiceManager: AppServiceManager,
     private val userStorage: UserStorage,
 ) : ViewModel() {
     private val viewModelState: MutableStateFlow<HomeViewModelState> =
@@ -92,6 +93,20 @@ internal class NewHomeViewModel @Inject constructor(
             initialValue = viewModelState.value.toUiState(),
         )
 
+    init {
+        observeAppServices()
+    }
+
+    private fun observeAppServices() {
+        viewModelScope.launch {
+            appServiceManager.appServices
+                .filterNotNull()
+                .collect { appServices ->
+                    viewModelState.update { it.copy(appServices = appServices) }
+                }
+        }
+    }
+
     fun refreshAll() {
         viewModelState.update { it.copy(isLoading = true) }
 
@@ -99,18 +114,21 @@ internal class NewHomeViewModel @Inject constructor(
             val userInfoDeferred = async { homeRepository.getUserInfo() }
             val userDescriptionDeferred = async { homeRepository.getHomeDescription() }
             val recentCalendarDeferred = async { homeRepository.getRecentCalendar() }
-            val appServiceDeferred = async { getAppServiceUseCase() }
             val surveyDataDeferred = async { homeRepository.getHomeReviewForm() }
             val toastDataDeferred = async { homeRepository.getHomeFloatingToast() }
             val popularPostsDeferred = async { homeRepository.getHomePopularPosts() }
             val latestPostsDeferred = async { homeRepository.getHomeLatestPosts() }
+            val appServiceDeferred = async {
+                appServiceManager.fetchAppServices(forceUpdate = true)
+            }
+
+            appServiceDeferred.await()
 
             val userInfoResult = userInfoDeferred.await()
 
             val userDescription =
                 userDescriptionDeferred.await().successOr(UserInfo.UserDescription())
             val recentCalendar = recentCalendarDeferred.await().successOr(RecentCalendar())
-            val appService = appServiceDeferred.await().successOr(emptyList())
             val surveyData = surveyDataDeferred.await().successOr(ReviewForm.default)
             val toastData = toastDataDeferred.await().successOr(FloatingToast.default)
             val popularPostsData = popularPostsDeferred.await().successOr(emptyList())
@@ -138,7 +156,6 @@ internal class NewHomeViewModel @Inject constructor(
                     userInfo = userInfo,
                     userDescription = userDescription,
                     recentCalendar = recentCalendar,
-                    appServices = appService,
                     surveyData = surveyData.toModel(),
                     toastData = toastData.toModel(),
                     popularPostData = popularPostsData.map { post -> post.toModel() }.toImmutableList(),

--- a/feature/main/src/main/java/org/sopt/official/feature/main/MainViewModel.kt
+++ b/feature/main/src/main/java/org/sopt/official/feature/main/MainViewModel.kt
@@ -31,14 +31,15 @@ import jakarta.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.sopt.official.domain.home.AppServiceManager
 import org.sopt.official.domain.home.model.AppService
-import org.sopt.official.domain.home.usecase.GetAppServiceUseCase
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    private val getAppServiceUseCase: GetAppServiceUseCase
+    private val appServiceManager: AppServiceManager
 ) : ViewModel() {
     private val _mainTabs = MutableStateFlow(MainTab.getActiveTabs(emptyList()))
     val mainTabs: StateFlow<List<MainTab>>
@@ -49,7 +50,7 @@ class MainViewModel @Inject constructor(
         get() = _badgeMap.asStateFlow()
 
     init {
-        fetchMainTabs()
+        observeAppServices()
     }
 
     fun updateBadge(badges: Map<String, String?>) {
@@ -60,17 +61,22 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    private fun fetchMainTabs() {
+    private fun observeAppServices() {
         viewModelScope.launch {
-            getAppServiceUseCase()
-                .onSuccess { appServices ->
+            appServiceManager.fetchAppServices()
+
+            appServiceManager.appServices
+                .filterNotNull()
+                .collect { appServices ->
                     updateMainTabs(appServices)
                 }
         }
     }
 
     private fun updateMainTabs(services: List<AppService>) {
-        val badgeByDeeplink = services.associate { it.deepLink to it.alarmBadge }
+        val badgeByDeeplink = services.associate {
+            it.deepLink to if (it.displayAlarmBadge) it.alarmBadge else null
+        }
 
         _mainTabs.update {
             MainTab.getActiveTabs(services.map { it.deepLink })

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogScreen.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogScreen.kt
@@ -71,7 +71,7 @@ internal fun SoptLogRoute(
     viewModel: SoptLogViewModel = hiltViewModel()
 ) {
     LaunchedEffect(Unit) {
-        viewModel.getSoptLogInfo()
+        viewModel.getSoptLogInfoData()
     }
 
     LaunchedEffect(Unit) {
@@ -102,7 +102,7 @@ internal fun SoptLogRoute(
     when {
         soptLogState.isLoading -> LoadingIndicator()
         soptLogState.isError -> {
-            NetworkErrorDialog(onConfirm = viewModel::getSoptLogInfo)
+            NetworkErrorDialog(onConfirm = viewModel::getSoptLogInfoData)
         }
 
         else -> {
@@ -170,7 +170,7 @@ private fun SoptlogScreen(
             // 활동 기수 여부에 관계없이 앱잼참여 회원만 보여줌 (앱잼탬프 기간만)
             // 앱잼 기간 솝탬프의 경우는 isAppjamJoined 가 true인 경우에만 보여줌 (앱잼 참여인 경우에만)
             // 일반 솝탬프의 경우는 (기존) soptLogInfo.isActive인 경우에만 보여줌 (활동 기수인 경우에만)
-            if (soptLogInfo.isActive) {
+            if (isAppjamJoined) {
                 SoptLogSection(
                     title = "솝탬프 로그",
                     items = MySoptLogItemType.entries.filter { it.category == SoptLogCategory.SOPTAMP }.toImmutableList(),

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogScreen.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogScreen.kt
@@ -56,7 +56,6 @@ import org.sopt.official.designsystem.SoptTheme
 import org.sopt.official.designsystem.component.dialog.NetworkErrorDialog
 import org.sopt.official.designsystem.component.indicator.LoadingIndicator
 import org.sopt.official.domain.soptlog.model.SoptLogInfo
-import org.sopt.official.feature.soptlog.component.SoptLogEmptySection
 import org.sopt.official.feature.soptlog.component.SoptLogSection
 import org.sopt.official.feature.soptlog.component.TodayFortuneBanner
 import org.sopt.official.feature.soptlog.model.MySoptLogItemType

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogScreen.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogScreen.kt
@@ -169,7 +169,8 @@ private fun SoptlogScreen(
             // 활동 기수 여부에 관계없이 앱잼참여 회원만 보여줌 (앱잼탬프 기간만)
             // 앱잼 기간 솝탬프의 경우는 isAppjamJoined 가 true인 경우에만 보여줌 (앱잼 참여인 경우에만)
             // 일반 솝탬프의 경우는 (기존) soptLogInfo.isActive인 경우에만 보여줌 (활동 기수인 경우에만)
-            if (soptLogInfo.isActive) {
+            // 2026-05-21 기획 상으로 앱잼 기간에는 임시 숨김 처리 개편예정
+            /*if (soptLogInfo.isActive) {
                 SoptLogSection(
                     title = "솝탬프 로그",
                     items = MySoptLogItemType.entries.filter { it.category == SoptLogCategory.SOPTAMP }.toImmutableList(),
@@ -181,7 +182,7 @@ private fun SoptlogScreen(
                     }
                 )
                 Spacer(modifier = Modifier.height(28.dp))
-            }
+            }*/
 
             // 각 섹션 엠티뷰 표시 시
             /*SoptLogEmptySection(

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogScreen.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogScreen.kt
@@ -170,7 +170,7 @@ private fun SoptlogScreen(
             // 활동 기수 여부에 관계없이 앱잼참여 회원만 보여줌 (앱잼탬프 기간만)
             // 앱잼 기간 솝탬프의 경우는 isAppjamJoined 가 true인 경우에만 보여줌 (앱잼 참여인 경우에만)
             // 일반 솝탬프의 경우는 (기존) soptLogInfo.isActive인 경우에만 보여줌 (활동 기수인 경우에만)
-            if (isAppjamJoined) {
+            if (soptLogInfo.isActive) {
                 SoptLogSection(
                     title = "솝탬프 로그",
                     items = MySoptLogItemType.entries.filter { it.category == SoptLogCategory.SOPTAMP }.toImmutableList(),
@@ -184,10 +184,17 @@ private fun SoptlogScreen(
                 Spacer(modifier = Modifier.height(28.dp))
             }
 
-            // TODO: 운영 서버 콕 찌르기 API 불안정 이슈로 콕 찌르기 로그를 엠티뷰로 표시함.
-            // TODO: 해당 이슈 해결되면 엠티뷰 제거하고 원래 SoptLogSection 표시 해야 함.
-            SoptLogEmptySection(
+            // 각 섹션 엠티뷰 표시 시
+            /*SoptLogEmptySection(
                 content = "콕찌르기 기능 정비 중입니다.\n곧 사용할 수 있어요!"
+            )*/
+            SoptLogSection(
+                title = "콕찌르기 로그",
+                items = MySoptLogItemType.entries.filter { it.category == SoptLogCategory.POKE }.toImmutableList(),
+                soptLogInfo = soptLogInfo,
+                onItemClick = {
+                    onNavigationClick(it.url)
+                }
             )
 
             Spacer(modifier = Modifier.height(38.dp))

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/model/MySoptLogItemType.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/model/MySoptLogItemType.kt
@@ -36,7 +36,7 @@ internal enum class MySoptLogItemType(
 ) {
     // 솝탬프 로그
     // 일반 솝탬프의 경우는 (기존) url = "soptamp" / 앱잼탬프만 appjamtamp 사용 (앱잼탬프 기간만)
-    COMPLETED_MISSION(title = "완료미션", category = SoptLogCategory.SOPTAMP, url = "appjamtamp", count = { it.soptampCount ?: 0 }),
+    COMPLETED_MISSION(title = "완료미션", category = SoptLogCategory.SOPTAMP, url = "soptamp", count = { it.soptampCount ?: 0 }),
     VIEW_COUNT(title = "조회수", category = SoptLogCategory.SOPTAMP, hasHelpIcon = true, hasArrow = false, count = { it.viewCount ?: 0 }),
     RECEIVED_CLAP(title = "받은 박수", category = SoptLogCategory.SOPTAMP, hasArrow = false, count = { it.myClapCount ?: 0 }),
     SENT_CLAP(title = "쳐준 박수", category = SoptLogCategory.SOPTAMP, hasArrow = false, count = { it.clapCount ?: 0 }),

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/model/MySoptLogItemType.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/model/MySoptLogItemType.kt
@@ -36,7 +36,7 @@ internal enum class MySoptLogItemType(
 ) {
     // 솝탬프 로그
     // 일반 솝탬프의 경우는 (기존) url = "soptamp" / 앱잼탬프만 appjamtamp 사용 (앱잼탬프 기간만)
-    COMPLETED_MISSION(title = "완료미션", category = SoptLogCategory.SOPTAMP, url = "soptamp", count = { it.soptampCount ?: 0 }),
+    COMPLETED_MISSION(title = "완료미션", category = SoptLogCategory.SOPTAMP, url = "appjamtamp", count = { it.soptampCount ?: 0 }),
     VIEW_COUNT(title = "조회수", category = SoptLogCategory.SOPTAMP, hasHelpIcon = true, hasArrow = false, count = { it.viewCount ?: 0 }),
     RECEIVED_CLAP(title = "받은 박수", category = SoptLogCategory.SOPTAMP, hasArrow = false, count = { it.myClapCount ?: 0 }),
     SENT_CLAP(title = "쳐준 박수", category = SoptLogCategory.SOPTAMP, hasArrow = false, count = { it.clapCount ?: 0 }),

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/navigation/SoptLogUrl.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/navigation/SoptLogUrl.kt
@@ -26,7 +26,7 @@ package org.sopt.official.feature.soptlog.navigation
 
 enum class SoptLogUrl(val url: String) {
     POKE("home/poke"),
-    SOPTAMP("soptamp"),  // 일반 솝탬프의 경우는 (기존) url = "soptamp" / 앱잼탬프만 appjamtamp 사용 (앱잼탬프 기간만)
+    SOPTAMP("appjamtamp"),  // 일반 솝탬프의 경우는 (기존) url = "soptamp" / 앱잼탬프만 appjamtamp 사용 (앱잼탬프 기간만)
     POKE_FRIEND_SUMMARY("home/poke/friend-list-summary"),
     UNKNOWN("");
 


### PR DESCRIPTION
## Related issue 🛠
- closed #1582 

## Work Description ✏️
앱잼탬프 수정 사항을 반영하였습니다
- AppjamtampRankingScreen 내 주요 텍스트 문구 변경 (랭킹 -> 현황, 득점 랭킹 -> 미션 달성 보드 등)
- TodayScoreRaking 컴포넌트 내 순위 아이콘(Icon) 제거 및 레이아웃 패딩 조정
- AppjamtampFloatingButton의 버튼 텍스트를 '앱잼팀 현황'으로 변경

추가적으로 뱃지 숨김을 구현하면서 app-service의 중복 호출 구조도 개선하였습니다
**이전 문제점**
- 각 ViewModel이 서버에서 UseCase로 호출하여 데이터 파편화 현상이 발생할 수 있었습니다 (아마 이 부분이 뱃지의 수에 +1이 추가되는 이슈의 문제 원인 중 하나일 거라 예상)
- 같은 API 요청을 통해 불필요한 네트워크 리소스 소모와 CPU 연산 중복이 발생하는 문제가 있었습니다

**현재 개선점**
- 각 ViewModel에서 Singleton으로 주입한 AppServiceManager 를 구현하여 StateFlow를 통해 네트워크와 CPU 낭비 없이 캐싱하여 리소스 소모를 최소화하였습니다 또한 단일 진실 소스로 사용되어 데이터 파편화 현상을 방지하였습니다

## To Reviewers 📢
앱잼탬프도 QA를 위해 열어두었습니다!
- 추가적으로 iOS와 구현을 맞추기 위해 앱에서 뱃지 숨김 서버 필드를 사용하지 않는 점을 수정하였습니다