### PR TITLE
[Mod/#1587] SP2 홈 화면 UI 개편

### DIFF
--- a/app/src/main/java/org/sopt/official/config/FcmPushTokenManager.kt
+++ b/app/src/main/java/org/sopt/official/config/FcmPushTokenManager.kt
@@ -1,0 +1,48 @@
+package org.sopt.official.config
+
+import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.tasks.await
+import org.sopt.official.domain.notification.usecase.RegisterPushTokenUseCase
+import org.sopt.official.localstorage.source.UserStorage
+import org.sopt.official.model.UserStatus
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * FCM 토큰 조회, 로컬 저장, 서버 등록을 앱 전역에서 일관되게 처리하는 Manger class
+ */
+@Singleton
+class FcmPushTokenManager @Inject constructor(
+    private val registerPushTokenUseCase: RegisterPushTokenUseCase,
+    private val userStorage: UserStorage,
+) {
+    /**
+     * 현재 기기의 FCM 토큰을 조회하고 서버에 등록한다.
+     *
+     * 로그인 성공처럼 인증 토큰 저장이 완료된 직후 현재 FCM 토큰을 서버와 동기화해야 할 때 사용한다.
+     */
+    suspend fun registerCurrentToken() {
+        val token = FirebaseMessaging.getInstance().token.await()
+        saveAndRegisterToken(token)
+    }
+
+    /**
+     * Firebase에서 새로 발급한 FCM 토큰을 인증 유저인 경우 서버에 재등록한다.
+     *
+     * FCM 토큰 갱신 콜백에서 호출한다.
+     */
+    suspend fun registerPushTokenIfAuthenticated(token: String) {
+        if (userStorage.userStatus.first() == UserStatus.UNAUTHENTICATED) return
+
+        saveAndRegisterToken(token)
+    }
+
+    /**
+     * 전달받은 FCM 토큰을 로컬에 저장한 뒤 서버에 등록한다.
+     */
+    private suspend fun saveAndRegisterToken(token: String) {
+        userStorage.savePushToken(token)
+        registerPushTokenUseCase(pushToken = token)
+    }
+}

--- a/app/src/main/java/org/sopt/official/config/messaging/SoptFirebaseMessagingService.kt
+++ b/app/src/main/java/org/sopt/official/config/messaging/SoptFirebaseMessagingService.kt
@@ -32,34 +32,29 @@ import androidx.lifecycle.lifecycleScope
 import com.google.firebase.messaging.RemoteMessage
 import com.skydoves.firebase.messaging.lifecycle.ktx.LifecycleAwareFirebaseMessagingService
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.sopt.official.R
-import org.sopt.official.domain.notification.usecase.RegisterPushTokenUseCase
+import org.sopt.official.config.FcmPushTokenManager
 import org.sopt.official.feature.notification.SchemeActivity
-import org.sopt.official.localstorage.source.UserStorage
-import org.sopt.official.model.UserStatus
+import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class SoptFirebaseMessagingService : LifecycleAwareFirebaseMessagingService() {
 
     @Inject
-    lateinit var userStorage: UserStorage
+    lateinit var fcmPushTokenManager: FcmPushTokenManager
 
-    @Inject
-    lateinit var registerPushTokenUseCase: RegisterPushTokenUseCase
-
+    // 토큰이 갱신되는 시점에만 재등록
     override fun onNewToken(token: String) {
         lifecycleScope.launch {
-            val currentStatus = userStorage.userStatus.first()
-
-            if (currentStatus == UserStatus.UNAUTHENTICATED) {
-                return@launch
+            runCatching {
+                fcmPushTokenManager.registerPushTokenIfAuthenticated(token)
+            }.onSuccess {
+                Timber.d("갱신된 FCM 토큰 서버 등록 성공")
+            }.onFailure {
+                Timber.e(it, "갱신된 FCM 토큰 서버 등록 실패")
             }
-
-            userStorage.savePushToken(token)
-            registerPushTokenUseCase(token)
         }
     }
 

--- a/app/src/main/java/org/sopt/official/feature/auth/AuthActivity.kt
+++ b/app/src/main/java/org/sopt/official/feature/auth/AuthActivity.kt
@@ -190,14 +190,13 @@ class AuthActivity : AppCompatActivity() {
                     }.onFailure {
                         Timber.e(it, "자동 로그인 후 FCM 토큰 서버 등록 실패")
                     }
-                }
-
-                startActivity(
-                    MainActivity.getIntent(
-                        context = this,
-                        args = MainActivity.StartArgs(UserStatus.ACTIVE)
+                    startActivity(
+                        MainActivity.getIntent(
+                            context = this@AuthActivity,
+                            args = MainActivity.StartArgs(UserStatus.ACTIVE)
+                        )
                     )
-                )
+                }
             }
         } catch (e: Exception) {
             Timber.e(e)

--- a/app/src/main/java/org/sopt/official/feature/auth/AuthActivity.kt
+++ b/app/src/main/java/org/sopt/official/feature/auth/AuthActivity.kt
@@ -43,10 +43,13 @@ import androidx.core.app.NotificationCompat
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.sopt.official.R
 import org.sopt.official.common.util.getVersionName
 import org.sopt.official.common.util.launchPlayStore
+import org.sopt.official.config.FcmPushTokenManager
 import org.sopt.official.designsystem.SoptTheme
 import org.sopt.official.feature.auth.component.UpdateDialog
 import org.sopt.official.feature.main.MainActivity
@@ -65,6 +68,9 @@ class AuthActivity : AppCompatActivity() {
     lateinit var userStorage: UserStorage
     @Inject
     lateinit var tokenStorage: TokenStorage
+
+    @Inject
+    lateinit var fcmPushTokenManager: FcmPushTokenManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -178,6 +184,14 @@ class AuthActivity : AppCompatActivity() {
     private fun navigateToMainActivity(accessToken : String) {
         try {
             if (accessToken.isNotEmpty()) {
+                lifecycleScope.launch {
+                    runCatching {
+                        fcmPushTokenManager.registerCurrentToken()
+                    }.onFailure {
+                        Timber.e(it, "자동 로그인 후 FCM 토큰 서버 등록 실패")
+                    }
+                }
+
                 startActivity(
                     MainActivity.getIntent(
                         context = this,

--- a/app/src/main/java/org/sopt/official/feature/auth/feature/authmain/AuthMainViewModel.kt
+++ b/app/src/main/java/org/sopt/official/feature/auth/feature/authmain/AuthMainViewModel.kt
@@ -31,13 +31,16 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
+import org.sopt.official.config.FcmPushTokenManager
 import org.sopt.official.domain.auth.model.Auth
 import org.sopt.official.domain.auth.repository.AuthRepository
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class AuthMainViewModel @Inject constructor(
     private val authRepository: AuthRepository,
+    private val fcmPushTokenManager: FcmPushTokenManager
 ) : ViewModel() {
     private val _sideEffect = MutableSharedFlow<AuthMainSideEffect>()
     val sideEffect: SharedFlow<AuthMainSideEffect> = _sideEffect.asSharedFlow()
@@ -54,6 +57,13 @@ class AuthMainViewModel @Inject constructor(
                     accessToken = response.token,
                     refreshToken = response.refreshToken,
                 )
+
+                runCatching {
+                    fcmPushTokenManager.registerCurrentToken()
+                }.onFailure {
+                    Timber.e(it, "FCM 토큰 서버 등록 실패")
+                }
+
                 _sideEffect.emit(AuthMainSideEffect.NavigateToHome)
             }.onFailure {
                 _sideEffect.emit(AuthMainSideEffect.NavigateToAuthError)

--- a/feature/home/src/main/java/org/sopt/official/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/HomeRoute.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -276,22 +277,33 @@ private fun HomeScreenForMember(
 
             Spacer(modifier = Modifier.height(height = 12.dp))
 
+            Text(
+                text = "SOPT Playground",
+                style = typography.title14SB,
+                color = colors.onSurface400,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+            )
+
+            Spacer(modifier = Modifier.height(height = 12.dp))
+
             HomeShortcutButtonsForMember(
-                onPlaygroundClick = {
-                    homeShortcutNavigation.navigateToPlayground()
-                    trackClickEvent(tracker, "at36_playground_community")
+                onMemberClick = {
+                    homeShortcutNavigation.navigateToPlaygroundMember()
+                    trackClickEvent(tracker, "at36_member")
                 },
                 onStudyClick = {
                     homeShortcutNavigation.navigateToPlaygroundGroup()
                     trackClickEvent(tracker, "at36_moim")
                 },
-                onMemberClick = {
-                    homeShortcutNavigation.navigateToPlaygroundMember()
-                    trackClickEvent(tracker, "at36_member")
-                },
                 onProjectClick = {
                     homeShortcutNavigation.navigateToPlaygroundProject()
                     trackClickEvent(tracker, "at36_project")
+                },
+                onCoffeeChat = {
+                    homeShortcutNavigation.navigateToPlaygroundCoffeeChat()
+                    trackClickEvent(tracker, "at38_playground_coffee_chat")
                 },
                 modifier = Modifier
                     .padding(horizontal = 20.dp)
@@ -317,6 +329,7 @@ private fun HomeScreenForMember(
                     postList = popularPosts,
                     navigateToWebLink = homeAppServicesNavigation::navigateToWebUrl,
                     navigateToMemberProfile = homeAppServicesNavigation::navigateToPlaygroundMemberProfile,
+                    navigateToPlayground = homeShortcutNavigation::navigateToPlayground,
                     modifier = Modifier.padding(horizontal = 20.dp)
                 )
             }

--- a/feature/home/src/main/java/org/sopt/official/feature/home/NewHomeViewModel.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/NewHomeViewModel.kt
@@ -26,7 +26,6 @@ package org.sopt.official.feature.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -40,7 +39,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
 import org.sopt.official.common.util.successOr
 import org.sopt.official.domain.home.AppServiceManager
 import org.sopt.official.domain.home.model.AppService
@@ -53,7 +51,6 @@ import org.sopt.official.domain.home.model.UserStatus.ACTIVE
 import org.sopt.official.domain.home.model.UserStatus.INACTIVE
 import org.sopt.official.domain.home.model.UserStatus.UNAUTHENTICATED
 import org.sopt.official.domain.home.repository.HomeRepository
-import org.sopt.official.domain.notification.usecase.RegisterPushTokenUseCase
 import org.sopt.official.domain.poke.entity.ApiResult
 import org.sopt.official.domain.poke.entity.CheckNewInPoke
 import org.sopt.official.domain.poke.usecase.CheckNewInPokeUseCase
@@ -78,7 +75,6 @@ import javax.inject.Inject
 internal class NewHomeViewModel @Inject constructor(
     private val homeRepository: HomeRepository,
     private val checkNewInPokeUseCase: CheckNewInPokeUseCase,
-    private val registerPushTokenUseCase: RegisterPushTokenUseCase,
     private val appServiceManager: AppServiceManager,
     private val userStorage: UserStorage,
 ) : ViewModel() {
@@ -141,13 +137,6 @@ internal class NewHomeViewModel @Inject constructor(
                 userStorage.saveUserStatus(org.sopt.official.model.UserStatus.of(userInfo.user.userStatus.name))
             }
 
-            if (userInfo.user.userStatus != UNAUTHENTICATED) {
-                Timber.d("사용자 상태가 인증됨: ${userInfo.user.userStatus}, FCM 토큰 등록 시작")
-                registerFcmToken()
-            } else {
-                Timber.d("사용자 상태가 인증되지 않음: UNAUTHENTICATED, FCM 토큰 등록 건너뜀")
-            }
-
             viewModelState.update {
                 it.copy(
                     isError = userInfo.user.name.isBlank() || userDescription.activityDescription.isBlank(), // 반복 에러 대응 필요
@@ -161,26 +150,6 @@ internal class NewHomeViewModel @Inject constructor(
                     popularPostData = popularPostsData.map { post -> post.toModel() }.toImmutableList(),
                     latestPostData = latestPostData.map { post -> post.toModel() }.toImmutableList()
                 )
-            }
-        }
-    }
-
-    private fun registerFcmToken() {
-        viewModelScope.launch {
-            Timber.d("FCM 토큰 가져오기 시작")
-            runCatching {
-                FirebaseMessaging.getInstance().token.await()
-            }.onSuccess { token ->
-                Timber.d("FCM 토큰 가져오기 성공: $token")
-                runCatching {
-                    registerPushTokenUseCase(token)
-                }.onSuccess {
-                    Timber.d("FCM 토큰 서버 등록 성공: $token")
-                }.onFailure { error ->
-                    Timber.e(error, "FCM 토큰 서버 등록 실패: $token")
-                }
-            }.onFailure { error ->
-                Timber.e(error, "FCM 토큰 가져오기 실패")
             }
         }
     }

--- a/feature/home/src/main/java/org/sopt/official/feature/home/component/HomePopularNewsSection.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/component/HomePopularNewsSection.kt
@@ -27,12 +27,17 @@ package org.sopt.official.feature.home.component
 import androidx.compose.animation.core.EaseIn
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -40,17 +45,22 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.delay
+import org.sopt.official.common.util.noRippleClickable
 import org.sopt.official.designsystem.Orange200
 import org.sopt.official.designsystem.Orange300
 import org.sopt.official.designsystem.Orange500
 import org.sopt.official.designsystem.SoptTheme
+import org.sopt.official.feature.home.R
 import org.sopt.official.feature.home.model.HomePlaygroundPostModel
 
 private const val POPULAR_NEWS_LIST_SIZE = 3
@@ -60,6 +70,7 @@ internal fun HomePopularNewsSection(
     postList: ImmutableList<HomePlaygroundPostModel>,
     navigateToWebLink: (String) -> Unit,
     navigateToMemberProfile: (Int) -> Unit,
+    navigateToPlayground: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var highlightedIndex by remember { mutableIntStateOf(0) }
@@ -74,11 +85,44 @@ internal fun HomePopularNewsSection(
     Column(
         modifier = modifier
     ) {
-        Text(
-            text = "실시간 인기글 🔥",
-            style = SoptTheme.typography.heading20B,
-            color = SoptTheme.colors.primary
-        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(3.dp),
+        ) {
+            Text(
+                text = "지금 인기 소식",
+                style = SoptTheme.typography.heading20B,
+                color = SoptTheme.colors.primary
+            )
+
+            Image(
+                imageVector = ImageVector.vectorResource(id = R.drawable.ic_fire) ,
+                contentDescription = null,
+                modifier = Modifier.padding(vertical = 5.dp)
+            )
+
+            Spacer(Modifier.weight(1f))
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.noRippleClickable {
+                    navigateToPlayground()
+                }
+            ) {
+                Text(
+                    text = "전체보기",
+                    style = SoptTheme.typography.label12SB,
+                    color = SoptTheme.colors.onSurface300
+                )
+
+                Icon(
+                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_arrow_right),
+                    contentDescription = "전체보기",
+                    tint = SoptTheme.colors.onSurface300,
+                    modifier = Modifier.size(size = 16.dp)
+                )
+            }
+        }
 
         Spacer(modifier = Modifier.height(16.dp))
 
@@ -149,7 +193,8 @@ private fun HomePlaygroundSectionPreview() {
                 )
             ),
             navigateToWebLink = {},
-            navigateToMemberProfile = {}
+            navigateToMemberProfile = {},
+            navigateToPlayground = {}
         )
     }
 }

--- a/feature/home/src/main/java/org/sopt/official/feature/home/component/HomeShortcutButtons.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/component/HomeShortcutButtons.kt
@@ -55,26 +55,27 @@ import org.sopt.official.feature.home.R.drawable.ic_file_text_filled
 import org.sopt.official.feature.home.R.drawable.ic_folder
 import org.sopt.official.feature.home.R.drawable.ic_homepage
 import org.sopt.official.feature.home.R.drawable.ic_instagram_40
-import org.sopt.official.feature.home.R.drawable.ic_member
+import org.sopt.official.feature.home.R.drawable.ic_coffeechat
 import org.sopt.official.feature.home.R.drawable.ic_moim
 import org.sopt.official.feature.home.R.drawable.is_playground
+import org.sopt.official.feature.home.R.drawable.ic_member
 
 @Composable
 internal fun HomeShortcutButtonsForMember(
-    onPlaygroundClick: () -> Unit,
-    onStudyClick: () -> Unit,
     onMemberClick: () -> Unit,
+    onStudyClick: () -> Unit,
     onProjectClick: () -> Unit,
-    modifier: Modifier = Modifier,
+    onCoffeeChat: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Row(
         horizontalArrangement = SpaceBetween,
         modifier = modifier.fillMaxWidth(),
     ) {
         HomeShortcutButton(
-            icon = is_playground,
-            text = "Playground",
-            onClick = onPlaygroundClick,
+            icon = ic_member,
+            text = "멤버",
+            onClick = onMemberClick,
         )
         HomeShortcutButton(
             icon = ic_moim,
@@ -82,14 +83,14 @@ internal fun HomeShortcutButtonsForMember(
             onClick = onStudyClick,
         )
         HomeShortcutButton(
-            icon = ic_member,
-            text = "멤버",
-            onClick = onMemberClick,
-        )
-        HomeShortcutButton(
             icon = ic_file_text_filled,
             text = "프로젝트",
             onClick = onProjectClick,
+        )
+        HomeShortcutButton(
+            icon = ic_coffeechat,
+            text = "커피솝",
+            onClick = onCoffeeChat,
         )
     }
 }
@@ -99,10 +100,10 @@ internal fun HomeShortcutButtonsForMember(
 private fun HomeShortcutButtonsForMemberPreview() {
     SoptTheme {
         HomeShortcutButtonsForMember(
-            onPlaygroundClick = { },
-            onStudyClick = { },
             onMemberClick = { },
+            onStudyClick = { },
             onProjectClick = { },
+            onCoffeeChat = { }
         )
     }
 }

--- a/feature/home/src/main/java/org/sopt/official/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/navigation/HomeNavigation.kt
@@ -35,6 +35,7 @@ sealed interface HomeNavigation {
         fun navigateToPlaygroundGroup()
         fun navigateToPlaygroundMember()
         fun navigateToPlaygroundProject()
+        fun navigateToPlaygroundCoffeeChat()
         fun navigateToSoptHomepage()
         fun navigateToSoptReview()
         fun navigateToSoptProject()

--- a/feature/home/src/main/res/drawable/ic_coffeechat.xml
+++ b/feature/home/src/main/res/drawable/ic_coffeechat.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="40dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40">
+  <path
+      android:pathData="M25.479,18.641H32.468C35.339,18.641 37.666,20.968 37.666,23.838C37.666,26.708 35.339,29.035 32.468,29.035H25.479"
+      android:strokeWidth="2.509"
+      android:fillColor="#00000000"
+      android:strokeColor="#808087"/>
+  <path
+      android:pathData="M4.333,16.49H32.291V21.149C32.291,28.869 26.032,35.128 18.312,35.128C10.592,35.128 4.333,28.869 4.333,21.149V16.49Z"
+      android:fillColor="#808087"/>
+  <path
+      android:pathData="M18.312,12.631C22.107,12.631 25.51,13.164 27.935,14.004C29.151,14.425 30.078,14.908 30.685,15.405C31.298,15.907 31.49,16.339 31.49,16.67C31.49,17 31.298,17.433 30.685,17.934C30.078,18.431 29.151,18.914 27.935,19.335C25.51,20.174 22.107,20.709 18.312,20.709C14.516,20.709 11.114,20.174 8.689,19.335C7.473,18.914 6.546,18.431 5.939,17.934C5.326,17.433 5.133,17 5.133,16.67C5.133,16.339 5.326,15.907 5.939,15.405C6.546,14.908 7.473,14.425 8.689,14.004C11.114,13.164 14.516,12.631 18.312,12.631Z"
+      android:strokeWidth="1.6"
+      android:fillColor="#202025"
+      android:strokeColor="#808087"/>
+  <path
+      android:pathData="M17.78,6.585C17.78,4.383 15.94,3.328 15.02,2.87C16.909,2.87 19.814,3.971 20.541,5.897C21.468,8.355 19.965,9.881 18.071,11.675C16.473,13.188 19.233,15.619 20.105,16.49C17.49,16.49 14.729,14.151 14.729,11.813C14.729,9.336 17.78,9.336 17.78,6.585Z"
+      android:fillColor="#808087"/>
+</vector>

--- a/feature/home/src/main/res/drawable/ic_fire.xml
+++ b/feature/home/src/main/res/drawable/ic_fire.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M16.875,12.082C16.875,15.873 13.794,18.955 10.004,18.957H10.008H10H10.004C6.215,18.955 3.133,15.873 3.133,12.082C3.133,11.199 3.133,9.365 4.933,7.107C5.013,7.008 5.121,6.936 5.243,6.9C5.364,6.864 5.494,6.866 5.615,6.906C5.735,6.946 5.841,7.022 5.917,7.123C5.993,7.225 6.037,7.347 6.042,7.474C6.05,7.807 6.192,8.582 6.533,8.849C6.617,8.915 6.742,8.982 7.008,8.924C7.575,8.807 7.667,8.382 7.708,6.874V6.871C7.758,5.004 7.827,2.449 11,1.091C11.2,1.008 11.417,1.024 11.592,1.141C11.767,1.258 11.875,1.458 11.875,1.666C11.875,3.424 12.883,4.599 14.05,5.958C15.375,7.491 16.875,9.241 16.875,12.083"
+      android:fillColor="#F04251"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M9.997,16.458C12.047,16.458 13.539,14.791 13.539,12.5C13.539,11.316 12.547,9.15 11.056,8.583C10.965,8.55 10.868,8.537 10.771,8.546C10.675,8.554 10.581,8.584 10.497,8.633C10.415,8.684 10.346,8.754 10.296,8.836C10.245,8.919 10.214,9.012 10.206,9.108C10.131,9.958 9.797,11.033 9.089,11.475C8.631,11.766 8.031,11.766 7.297,11.491C7.202,11.457 7.101,11.446 7.001,11.46C6.901,11.473 6.805,11.51 6.723,11.568C6.64,11.626 6.573,11.703 6.526,11.793C6.48,11.883 6.456,11.982 6.456,12.083C6.456,14.5 8.047,16.458 9.997,16.458Z"
+      android:fillColor="#FE818B"/>
+</vector>

--- a/feature/main/src/main/java/org/sopt/official/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/org/sopt/official/feature/main/MainScreen.kt
@@ -257,6 +257,7 @@ fun MainScreen(
                                 override fun navigateToPlaygroundGroup() = context.startActivity(getIntent(PlaygroundWebLink.GROUP_STUDY))
                                 override fun navigateToPlaygroundMember() = context.startActivity(getIntent(PlaygroundWebLink.MEMBER))
                                 override fun navigateToPlaygroundProject() = context.startActivity(getIntent(PlaygroundWebLink.PROJECT))
+                                override fun navigateToPlaygroundCoffeeChat() = context.startActivity(getIntent(PlaygroundWebLink.COFFEE_CHAT))
                                 override fun navigateToSoptHomepage() = context.startActivity(getIntent(SoptWebLink.OFFICIAL_HOMEPAGE))
                                 override fun navigateToSoptReview() = context.startActivity(getIntent(SoptWebLink.REVIEW))
                                 override fun navigateToSoptProject() = context.startActivity(getIntent(SoptWebLink.PROJECT))

--- a/feature/main/src/main/java/org/sopt/official/feature/main/model/WebLink.kt
+++ b/feature/main/src/main/java/org/sopt/official/feature/main/model/WebLink.kt
@@ -39,6 +39,7 @@ internal object PlaygroundWebLink {
     const val EDIT_PROFILE = OFFICIAL_HOMEPAGE + "members/edit"
     const val PROJECT = OFFICIAL_HOMEPAGE + "projects"
     const val GROUP_STUDY = OFFICIAL_HOMEPAGE + "group"
+    const val COFFEE_CHAT = OFFICIAL_HOMEPAGE + "coffeechat"
 
     const val WRITE = OFFICIAL_HOMEPAGE + "feed/upload"
     const val MAKE_FLASH = OFFICIAL_HOMEPAGE + "group/make/flash"


### PR DESCRIPTION
## Related issue 🛠
- closed #1587

## Work Description ✏️
- 홈 화면 플레이그라운드 영역 UI 수정

- FCM 토큰 저장 및 서버 등록 구조 개선
- 로그인 성공 시점에 현재 FCM 토큰을 서버에 등록하도록 변경
- 자동 로그인 후 Main 진입 시점에도 기존 `accessToken.isNotEmpty()` 기준을 유지하여 FCM 토큰 등록 로직 적용
- 홈 진입 및 새로고침 시마다 `push-token` API가 반복 호출되던 구조 제거
- FCM 토큰 갱신 시점에는 `SoptFirebaseMessagingService.onNewToken`을 통해 재등록하도록 정리

<b>이전 문제점</b>
- `NewHomeViewModel.refreshAll()` 내부에서 인증 유저일 때마다 FCM 토큰을 조회하고 `POST /user/push-token`을 호출하고 있었습니다.
- 이로 인해 홈 진입, 네트워크 에러 재시도, 새로고침 시점마다 동일한 FCM 토큰 등록 요청이 반복되는 구조 였습니다.

<b> 개선점</b>
- `AuthMainViewModel`에서 구글 로그인 성공 후 인증 토큰 저장이 완료된 시점에 현재 FCM 토큰을 서버에 등록하도록 변경하였습니다.
- `AuthActivity`에서는 기존 자동 로그인 판단 기준인 `accessToken.isNotEmpty()`를 유지하면서 Main 진입 시 FCM 토큰 등록을 수행하도록 정리하였습니다.
- `NewHomeViewModel`에서 FCM 토큰 등록 로직을 제거하여 홈 진입 및 새로고침마다 `push-token` API가 호출되지 않도록 개선하였습니다.


## Screenshot 📸
<img width="360" alt="image" src="https://github.com/user-attachments/assets/fff80f10-9c01-4741-a4a3-9ae305a66f3c" />

## To Reviewers 📢
FCM 토큰 저장 및 갱신 구조에 대해 더 나은 의견이 있다면 공유해 주시면 감사하겠습니다.