### PR TITLE
[MOD#1594] BuildConfig.DEBUG 여부에 따른 앱잼탬프/일반 솝탬프 분기 처리 및 API 호출 로직 수정

### DIFF
--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogScreen.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogScreen.kt
@@ -52,6 +52,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.toImmutableList
 import org.sopt.official.analytics.EventType
 import org.sopt.official.analytics.compose.LocalTracker
+import org.sopt.official.common.BuildConfig
 import org.sopt.official.designsystem.SoptTheme
 import org.sopt.official.designsystem.component.dialog.NetworkErrorDialog
 import org.sopt.official.designsystem.component.indicator.LoadingIndicator
@@ -70,7 +71,11 @@ internal fun SoptLogRoute(
     viewModel: SoptLogViewModel = hiltViewModel()
 ) {
     LaunchedEffect(Unit) {
-        viewModel.getSoptLogInfoData()
+        if (BuildConfig.DEBUG) { // Todo : 앱잼탬프 기간일 때 다시 열기 if Build.Debug 제거
+            viewModel.getSoptLogInfoData()
+        } else {
+            viewModel.getSoptLogInfo()
+        }
     }
 
     LaunchedEffect(Unit) {
@@ -101,7 +106,11 @@ internal fun SoptLogRoute(
     when {
         soptLogState.isLoading -> LoadingIndicator()
         soptLogState.isError -> {
-            NetworkErrorDialog(onConfirm = viewModel::getSoptLogInfoData)
+            if (BuildConfig.DEBUG) { // Todo : 앱잼탬프 기간일 때 다시 열기 if Build.Debug 제거
+                NetworkErrorDialog(onConfirm = viewModel::getSoptLogInfoData)
+            } else {
+                NetworkErrorDialog(onConfirm = viewModel::getSoptLogInfo)
+            }
         }
 
         else -> {

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/model/MySoptLogItemType.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/model/MySoptLogItemType.kt
@@ -24,6 +24,7 @@
  */
 package org.sopt.official.feature.soptlog.model
 
+import org.sopt.official.common.BuildConfig
 import org.sopt.official.domain.soptlog.model.SoptLogInfo
 
 internal enum class MySoptLogItemType(
@@ -36,7 +37,8 @@ internal enum class MySoptLogItemType(
 ) {
     // 솝탬프 로그
     // 일반 솝탬프의 경우는 (기존) url = "soptamp" / 앱잼탬프만 appjamtamp 사용 (앱잼탬프 기간만)
-    COMPLETED_MISSION(title = "완료미션", category = SoptLogCategory.SOPTAMP, url = "soptamp", count = { it.soptampCount ?: 0 }),
+    // Todo : 앱잼탬프 기간일 때 다시 열기 if Build.Debug 제거
+    COMPLETED_MISSION(title = "완료미션", category = SoptLogCategory.SOPTAMP, url = if (BuildConfig.DEBUG) "appjamtamp" else "soptamp", count = { it.soptampCount ?: 0 }),
     VIEW_COUNT(title = "조회수", category = SoptLogCategory.SOPTAMP, hasHelpIcon = true, hasArrow = false, count = { it.viewCount ?: 0 }),
     RECEIVED_CLAP(title = "받은 박수", category = SoptLogCategory.SOPTAMP, hasArrow = false, count = { it.myClapCount ?: 0 }),
     SENT_CLAP(title = "쳐준 박수", category = SoptLogCategory.SOPTAMP, hasArrow = false, count = { it.clapCount ?: 0 }),

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/navigation/SoptLogUrl.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/navigation/SoptLogUrl.kt
@@ -24,9 +24,13 @@
  */
 package org.sopt.official.feature.soptlog.navigation
 
+import org.sopt.official.common.BuildConfig
+
 enum class SoptLogUrl(val url: String) {
     POKE("home/poke"),
-    SOPTAMP("appjamtamp"),  // 일반 솝탬프의 경우는 (기존) url = "soptamp" / 앱잼탬프만 appjamtamp 사용 (앱잼탬프 기간만)
+
+    // Todo : 앱잼탬프 기간일 때 다시 열기 if Build.Debug 제거
+    SOPTAMP(if (BuildConfig.DEBUG) "appjamtamp" else "soptamp"),  // 일반 솝탬프의 경우는 (기존) url = "soptamp" / 앱잼탬프만 appjamtamp 사용 (앱잼탬프 기간만)
     POKE_FRIEND_SUMMARY("home/poke/friend-list-summary"),
     UNKNOWN("");
 


### PR DESCRIPTION
## Related issue 🛠
- closed #1594 

## Work Description ✏️
- SoptLogUrl 및 MySoptLogItemType에서 DEBUG 모드일 때만 "appjamtamp" URL을 사용하도록 변경
- SoptLogScreen 내 데이터 로딩 및 에러 재시도 로직에서 DEBUG 여부에 따라 getSoptLogInfoData와 getSoptLogInfo를 구분하여 호출하도록 수정

## To Reviewers 📢
급한 처리가 필요하여 부득이하게 해당 방법을 채택하였습니다
release, debug 모드에서 모두 빌드 확인은 하였으나 release 버전에서 솝탬프를 볼 수 없는 관계로 해당 내용까지 확인 완료하였습니다