### PR TITLE
[FIX#1604] 홈 서비스 관련 데이터 모델 및 파라미터 null 허용 처리

### DIFF
--- a/data/home/src/main/java/org/sopt/official/data/home/remote/response/HomeAppServiceResponseDto.kt
+++ b/data/home/src/main/java/org/sopt/official/data/home/remote/response/HomeAppServiceResponseDto.kt
@@ -36,7 +36,7 @@ internal data class HomeAppServiceResponseDto(
     @SerialName("alarmBadge")
     val alarmBadge: String,
     @SerialName("iconUrl")
-    val iconUrl: String,
+    val iconUrl: String?,
     @SerialName("deepLink")
-    val deepLink: String,
+    val deepLink: String?,
 )

--- a/domain/home/src/main/java/org/sopt/official/domain/home/model/AppService.kt
+++ b/domain/home/src/main/java/org/sopt/official/domain/home/model/AppService.kt
@@ -28,6 +28,6 @@ data class AppService(
     val serviceName: String,
     val displayAlarmBadge: Boolean,
     val alarmBadge: String,
-    val iconUrl: String,
-    val deepLink: String,
+    val iconUrl: String?,
+    val deepLink: String?,
 )

--- a/feature/home/src/main/java/org/sopt/official/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/HomeRoute.kt
@@ -93,7 +93,7 @@ internal fun HomeRoute(
     paddingValues: PaddingValues,
     userStatus: UserStatus,
     homeNavigation: HomeNavigation,
-    onUpdateBottomBadge: (Map<String, String>) -> Unit,
+    onUpdateBottomBadge: (Map<String?, String>) -> Unit,
     newHomeViewModel: NewHomeViewModel = hiltViewModel(),
 ) {
     val uiState by newHomeViewModel.uiState.collectAsStateWithLifecycle()

--- a/feature/home/src/main/java/org/sopt/official/feature/home/component/HomeEnjoySoptServicesBlock.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/component/HomeEnjoySoptServicesBlock.kt
@@ -61,7 +61,7 @@ import org.sopt.official.feature.home.model.HomeAppService
 @Composable
 internal fun HomeEnjoySoptServicesBlock(
     appServices: ImmutableList<HomeAppService>,
-    onAppServiceClick: (url: String, appServiceName: String) -> Unit,
+    onAppServiceClick: (url: String?, appServiceName: String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -103,7 +103,7 @@ private fun HomeEnjoySoptServicesBlockPreview() {
 @Composable
 private fun AppServiceItem(
     appService: HomeAppService,
-    onItemClick: (url: String, appServiceName: String) -> Unit,
+    onItemClick: (url: String?, appServiceName: String) -> Unit,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -119,7 +119,7 @@ private fun AppServiceItem(
                     )
                 } else {
                     UrlImage(
-                        url = appService.iconUrl,
+                        url = appService.iconUrl ?: "",
                         modifier = Modifier.size(size = 60.dp),
                     )
                 }

--- a/feature/home/src/main/java/org/sopt/official/feature/home/model/HomeUiState.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/model/HomeUiState.kt
@@ -158,8 +158,8 @@ internal data class HomeAppService(
     val serviceName: String = "",
     val isShowAlarmBadge: Boolean = false,
     val alarmBadgeContent: String = "",
-    val iconUrl: String = "",
-    val deepLink: String = "",
+    val iconUrl: String? = "",
+    val deepLink: String? = "",
     @DrawableRes val defaultIcon: Int? = null,
 )
 

--- a/feature/home/src/main/java/org/sopt/official/feature/home/model/HomeUiState.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/model/HomeUiState.kt
@@ -158,8 +158,8 @@ internal data class HomeAppService(
     val serviceName: String = "",
     val isShowAlarmBadge: Boolean = false,
     val alarmBadgeContent: String = "",
-    val iconUrl: String? = "",
-    val deepLink: String? = "",
+    val iconUrl: String? = null,
+    val deepLink: String? = null,
     @DrawableRes val defaultIcon: Int? = null,
 )
 

--- a/feature/home/src/main/java/org/sopt/official/feature/home/navigation/HomeNavigator.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/navigation/HomeNavigator.kt
@@ -47,7 +47,7 @@ fun NavGraphBuilder.homeNavGraph(
     userStatus: UserStatus,
     homeNavigation: HomeNavigation,
     paddingValues: PaddingValues,
-    onUpdateBottomBadge: (Map<String, String>) -> Unit
+    onUpdateBottomBadge: (Map<String?, String>) -> Unit
 ) {
     composable<Home> {
         HomeRoute(

--- a/feature/main/src/main/java/org/sopt/official/feature/main/MainTab.kt
+++ b/feature/main/src/main/java/org/sopt/official/feature/main/MainTab.kt
@@ -87,7 +87,7 @@ enum class MainTab(
             return entries.map { it.route }.any { predicate(it) }
         }
 
-        fun getActiveTabs(activeServices: List<String>): List<MainTab> {
+        fun getActiveTabs(activeServices: List<String?>): List<MainTab> {
             val activeServices = entries.filter { tab ->
                 tab.deeplink != null && activeServices.contains(tab.deeplink)
             }

--- a/feature/main/src/main/java/org/sopt/official/feature/main/MainViewModel.kt
+++ b/feature/main/src/main/java/org/sopt/official/feature/main/MainViewModel.kt
@@ -53,7 +53,7 @@ class MainViewModel @Inject constructor(
         observeAppServices()
     }
 
-    fun updateBadge(badges: Map<String, String?>) {
+    fun updateBadge(badges: Map<String?, String?>) {
         _badgeMap.update {
             _mainTabs.value.associateWith { tab ->
                 tab.deeplink?.let { badges[it] }


### PR DESCRIPTION
## Related issue 🛠
- closed #1604 

## Work Description ✏️
- `HomeAppServiceResponseDto`, `AppService`, `HomeAppService` 내 `iconUrl` 및 `deepLink` 타입을 `String?`로 변경하여 Null 안정성 확보
- `MainTab`, `MainViewModel`, `HomeNavigator` 등에서 사용하는 서비스 리스트 및 뱃지 업데이트 관련 파라미터 타입을 `String?`로 수정
- `HomeEnjoySoptServicesBlock`에서 `iconUrl`이 없는 경우에 대한 예외 처리 추가 (`url ?: ""`)

-> 솝레터 관련 API 응답값에 iconUrl, deeplink가 null로 응답되어 Error fetching app services kotlinx.serialization.json.internal.JsonDecodingException 이 발생하여 바텀바가 업데이트 되지 않는 현상을 수정하였습니다

<img width="150" height="323" alt="image" src="https://github.com/user-attachments/assets/7dc74b7a-a50d-4687-be99-b8764489ff11" />
