### PR TITLE
[FEAT/#1629] SP3 마이페이지, 솝트로그 앰플리튜드 추가

### DIFF
--- a/app/src/main/java/org/sopt/official/feature/navigator/NavigatorProviderIntent.kt
+++ b/app/src/main/java/org/sopt/official/feature/navigator/NavigatorProviderIntent.kt
@@ -52,8 +52,9 @@ class NavigatorProviderIntent @Inject constructor(
         notificationId
     )
 
-    override fun getAdjustSentenceActivityIntent(): Intent = AdjustSentenceActivity.getIntent(
-        context
+    override fun getAdjustSentenceActivityIntent(userStatus: UserStatus): Intent = AdjustSentenceActivity.getIntent(
+        context,
+        AdjustSentenceActivity.StartArgs(userStatus = userStatus.name),
     )
 
     override fun getPokeActivityIntent(userStatus: UserStatus): Intent {

--- a/core/common/src/main/java/org/sopt/official/common/navigator/DeepLinkType.kt
+++ b/core/common/src/main/java/org/sopt/official/common/navigator/DeepLinkType.kt
@@ -63,7 +63,7 @@ enum class DeepLinkType(
     },
     MY_PAGE_SOPTAMP("mypage/soptamp") {
         override fun getIntent(context: Context, userStatus: UserStatus, deepLink: String) =
-            userStatus.setIntent(navigator.getAdjustSentenceActivityIntent())
+            userStatus.setIntent(navigator.getAdjustSentenceActivityIntent(userStatus))
     },
     ATTENDANCE("home/attendance") {
         override fun getIntent(context: Context, userStatus: UserStatus, deepLink: String) =

--- a/core/common/src/main/java/org/sopt/official/common/navigator/NavigatorProvider.kt
+++ b/core/common/src/main/java/org/sopt/official/common/navigator/NavigatorProvider.kt
@@ -34,7 +34,7 @@ interface NavigatorProvider {
     fun getAuthActivityIntent(): Intent
     fun getNotificationActivityIntent(): Intent
     fun getNotificationDetailActivityIntent(notificationId: String): Intent
-    fun getAdjustSentenceActivityIntent(): Intent
+    fun getAdjustSentenceActivityIntent(userStatus: UserStatus): Intent
     fun getAttendanceActivityIntent(): Intent
     fun getSoptampActivityIntent(): Intent
     fun getAppjamtampActivityIntent(): Intent

--- a/feature/main/src/main/java/org/sopt/official/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/org/sopt/official/feature/main/MainScreen.kt
@@ -356,6 +356,7 @@ fun MainScreen(
                         )
 
                         myPageNavGraph(
+                            userStatus = userStatus,
                             navigateToSoptLog = {
                                 navigator.navController.navigate(SoptLog)
                             },
@@ -370,6 +371,7 @@ fun MainScreen(
                             }
                         ) {
                             soptLogNavGraph(
+                                userStatus = userStatus,
                                 soptLogNavigation = object : SoptLogNavigation {
                                     override fun navigateToDeepLink(url: String) {
                                         if (userStatus == UserStatus.UNAUTHENTICATED) isOpenDialog = true

--- a/feature/mypage/build.gradle.kts
+++ b/feature/mypage/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(projects.core.model)
     implementation(projects.core.navigation)
     implementation(projects.core.webview)
+    implementation(projects.core.analytics)
 
     implementation(platform(libs.firebase))
     implementation(libs.bundles.firebase)

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/MyPageScreen.kt
@@ -175,7 +175,6 @@ internal fun MyPageRoute(
                 title = "로그아웃",
                 onItemClick = {
                     viewModel.onAction(MyPageAction.RequestLogout)
-                    tracker.trackViewType(MypageAnalyticsEvent.CLICK_DONE_LOGOUT, viewType)
                 }
             ),
             MyPageUiModel.MyPageItem(
@@ -325,7 +324,10 @@ internal fun MyPageScreen(
                 dialogState = state.dialogState,
                 onDismissRequest = { onAction(MyPageAction.CloseDialog) },
                 onClearSoptampClick = { onAction(MyPageAction.ResetSoptamp) },
-                onLogoutClick = { onAction(MyPageAction.ConfirmLogout) },
+                onLogoutClick = {
+                    onAction(MyPageAction.ConfirmLogout)
+                    tracker.trackViewType(MypageAnalyticsEvent.CLICK_DONE_LOGOUT, viewType)
+                },
             )
         }
     }

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/MyPageScreen.kt
@@ -27,7 +27,6 @@ package org.sopt.official.feature.mypage
 import android.content.Intent
 import android.provider.Settings
 import androidx.compose.foundation.background
-import org.sopt.official.webview.view.WebViewActivity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -50,6 +49,9 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import org.sopt.official.analytics.Tracker
+import org.sopt.official.analytics.compose.LocalTracker
+import org.sopt.official.analytics.trackViewType
 import org.sopt.official.designsystem.SoptTheme
 import org.sopt.official.feature.mypage.component.MyPageDialog
 import org.sopt.official.feature.mypage.component.MyPageNavigatorButton
@@ -63,16 +65,21 @@ import org.sopt.official.feature.mypage.signout.SignOutActivity
 import org.sopt.official.feature.mypage.soptamp.ui.AdjustSentenceActivity
 import org.sopt.official.feature.mypage.web.WebUrlConstant
 import org.sopt.official.model.UserStatus
+import org.sopt.official.model.toViewType
+import org.sopt.official.webview.view.WebViewActivity
 
 @Composable
 internal fun MyPageRoute(
     navigateToSoptLog: () -> Unit,
     navigateToPlayGroundProfile: () -> Unit,
     onRestartApp: () -> Unit,
+    userStatus: UserStatus,
     viewModel: MyPageViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
+    val tracker = LocalTracker.current
     val urlHandler = LocalUriHandler.current
+    val viewType = userStatus.toViewType()
     val state by viewModel.state.collectAsStateWithLifecycle()
     val isAppjamMode by viewModel.isAppjamMode.collectAsStateWithLifecycle()
 
@@ -82,6 +89,10 @@ internal fun MyPageRoute(
                 is MyPageSideEffect.NavigateToAuth -> onRestartApp()
             }
         }
+    }
+
+    LaunchedEffect(Unit) {
+        tracker.trackViewType(MypageAnalyticsEvent.VIEW_MYPAGE_MAIN, viewType)
     }
 
     val serviceSectionItems = remember {
@@ -107,7 +118,10 @@ internal fun MyPageRoute(
             ),
             MyPageUiModel.MyPageItem(
                 title = "의견 보내기",
-                onItemClick = { urlHandler.openUri(WebUrlConstant.OPINION_KAKAO_CHAT) }
+                onItemClick = {
+                    urlHandler.openUri(WebUrlConstant.OPINION_KAKAO_CHAT)
+                    tracker.trackViewType(MypageAnalyticsEvent.CLICK_MYPAGE_FEEDBACK, viewType)
+                }
             )
         )
     }
@@ -123,6 +137,7 @@ internal fun MyPageRoute(
                         putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
                     }
                     context.startActivity(intent)
+                    tracker.trackViewType(MypageAnalyticsEvent.CLICK_MYPAGE_NOTIFICATION, viewType)
                 }
             )
         )
@@ -133,11 +148,22 @@ internal fun MyPageRoute(
             MyPageUiModel.Header(title = "솝탬프 설정"),
             MyPageUiModel.MyPageItem(
                 title = "한 마디 편집",
-                onItemClick = { context.startActivity(AdjustSentenceActivity.getIntent(context)) }
+                onItemClick = {
+                    context.startActivity(
+                        AdjustSentenceActivity.getIntent(
+                            context,
+                            AdjustSentenceActivity.StartArgs(userStatus = userStatus.name),
+                        )
+                    )
+                    tracker.trackViewType(MypageAnalyticsEvent.CLICK_MYPAGE_EDIT_STATUSMESSAGE, viewType)
+                }
             ),
             MyPageUiModel.MyPageItem(
                 title = "스탬프 초기화",
-                onItemClick = { viewModel.onAction(MyPageAction.ClearSoptamp) }
+                onItemClick = {
+                    viewModel.onAction(MyPageAction.ClearSoptamp)
+                    tracker.trackViewType(MypageAnalyticsEvent.CLICK_MYPAGE_RESET_STAMP, viewType)
+                }
             )
         )
     }
@@ -147,11 +173,17 @@ internal fun MyPageRoute(
             MyPageUiModel.Header(title = "기타"),
             MyPageUiModel.MyPageItem(
                 title = "로그아웃",
-                onItemClick = { viewModel.onAction(MyPageAction.RequestLogout) }
+                onItemClick = {
+                    viewModel.onAction(MyPageAction.RequestLogout)
+                    tracker.trackViewType(MypageAnalyticsEvent.CLICK_DONE_LOGOUT, viewType)
+                }
             ),
             MyPageUiModel.MyPageItem(
                 title = "탈퇴하기",
-                onItemClick = { context.startActivity(SignOutActivity.getIntent(context)) }
+                onItemClick = {
+                    context.startActivity(SignOutActivity.getIntent(context))
+                    tracker.trackViewType(MypageAnalyticsEvent.CLICK_MYPAGE_QUIT, viewType)
+                }
             )
         )
     }
@@ -177,6 +209,8 @@ internal fun MyPageRoute(
         onAction = viewModel::onAction,
         navigateToSoptLog = navigateToSoptLog,
         navigateToPlayGroundProfile = navigateToPlayGroundProfile,
+        tracker = tracker,
+        viewType = viewType
     )
 }
 
@@ -192,6 +226,8 @@ internal fun MyPageScreen(
     onAction: (MyPageAction) -> Unit,
     navigateToSoptLog: () -> Unit,
     navigateToPlayGroundProfile: () -> Unit,
+    tracker:Tracker,
+    viewType:String
 ) {
     val scrollState = rememberScrollState()
 
@@ -227,7 +263,10 @@ internal fun MyPageScreen(
                 text = "프로필 수정",
                 modifier = Modifier
                     .padding(horizontal = 20.dp),
-                onClick = navigateToPlayGroundProfile
+                onClick = {
+                    navigateToPlayGroundProfile()
+                    tracker.trackViewType(MypageAnalyticsEvent.CLICK_PROFILE_EDIT_BUTTON, viewType )
+                }
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -248,7 +287,10 @@ internal fun MyPageScreen(
                 shape = RoundedCornerShape(999.dp),
                 modifier = Modifier
                     .padding(horizontal = 20.dp),
-                onClick = navigateToSoptLog
+                onClick = {
+                    navigateToSoptLog()
+                    tracker.trackViewType(MypageAnalyticsEvent.CLICK_MYPAGE_SOPTLOG, viewType )
+                }
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -327,6 +369,8 @@ private fun ShowMyPageDialog(
 @Composable
 private fun MyPageScreenPreview() {
     SoptTheme {
+        val track = LocalTracker.current
+
         MyPageScreen(
             state = MyPageState(
                 userStatus = UserStatus.ACTIVE,
@@ -360,6 +404,8 @@ private fun MyPageScreenPreview() {
             onAction = {},
             navigateToSoptLog = {},
             navigateToPlayGroundProfile = {},
+            tracker = track,
+            viewType = "",
         )
     }
 }

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/MypageAnalytics.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/MypageAnalytics.kt
@@ -1,0 +1,20 @@
+package org.sopt.official.feature.mypage
+
+import org.sopt.official.analytics.AnalyticsEvent
+import org.sopt.official.analytics.EventType
+
+enum class MypageAnalyticsEvent(
+    override val type : EventType,
+    override val eventName : String
+):AnalyticsEvent {
+    VIEW_MYPAGE_MAIN(EventType.VIEW,"mapage_main"),
+    CLICK_PROFILE_EDIT_BUTTON(EventType.CLICK,"profile_edit_button"),
+    CLICK_MYPAGE_SOPTLOG(EventType.CLICK,"mypage_soptlog"),
+    CLICK_MYPAGE_FEEDBACK(EventType.CLICK,"mypage_feedback"),
+    CLICK_MYPAGE_NOTIFICATION(EventType.CLICK,"mypage_notification"),
+    CLICK_MYPAGE_EDIT_STATUSMESSAGE(EventType.CLICK,"mypage_edit_statusmessage"),
+    CLICK_DONE_EDIT_STATUSMESSAGE(EventType.CLICK,"done_edit_statusmessage"),
+    CLICK_MYPAGE_RESET_STAMP(EventType.CLICK,"mypage_reset_stamp"),
+    CLICK_DONE_LOGOUT(EventType.CLICK,"done_logout"),
+    CLICK_MYPAGE_QUIT(EventType.CLICK,"mypage_quit"),
+}

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/MypageAnalytics.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/MypageAnalytics.kt
@@ -7,7 +7,7 @@ enum class MypageAnalyticsEvent(
     override val type : EventType,
     override val eventName : String
 ):AnalyticsEvent {
-    VIEW_MYPAGE_MAIN(EventType.VIEW,"mapage_main"),
+    VIEW_MYPAGE_MAIN(EventType.VIEW,"mypage_main"),
     CLICK_PROFILE_EDIT_BUTTON(EventType.CLICK,"profile_edit_button"),
     CLICK_MYPAGE_SOPTLOG(EventType.CLICK,"mypage_soptlog"),
     CLICK_MYPAGE_FEEDBACK(EventType.CLICK,"mypage_feedback"),

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/navigation/MyPageNavigator.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/navigation/MyPageNavigator.kt
@@ -33,6 +33,7 @@ import kotlinx.serialization.Serializable
 import org.sopt.official.core.navigation.MainTabRoute
 import org.sopt.official.core.navigation.Route
 import org.sopt.official.feature.mypage.MyPageRoute
+import org.sopt.official.model.UserStatus
 
 @Serializable
 data object MyPageGraph : MainTabRoute
@@ -45,6 +46,7 @@ fun NavController.navigateToMyPage(navOptions: NavOptions? = null) {
 }
 
 fun NavGraphBuilder.myPageNavGraph(
+    userStatus: UserStatus,
     navigateToSoptLog: () -> Unit,
     navigateToAuthActivity: () -> Unit,
     navigateToPlayGroundProfile: () -> Unit,
@@ -56,6 +58,7 @@ fun NavGraphBuilder.myPageNavGraph(
                 navigateToSoptLog = navigateToSoptLog,
                 navigateToPlayGroundProfile = navigateToPlayGroundProfile,
                 onRestartApp = navigateToAuthActivity,
+                userStatus = userStatus
             )
         }
         builder()

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/soptamp/ui/AdjustSentenceActivity.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/soptamp/ui/AdjustSentenceActivity.kt
@@ -43,23 +43,38 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import dagger.hilt.android.AndroidEntryPoint
+import java.io.Serializable
+import org.sopt.official.analytics.compose.LocalTracker
+import org.sopt.official.analytics.trackViewType
+import org.sopt.official.common.util.serializableExtra
 import org.sopt.official.common.view.toast
 import org.sopt.official.designsystem.SoptTheme
+import org.sopt.official.feature.mypage.MypageAnalyticsEvent
 import org.sopt.official.feature.mypage.R
 import org.sopt.official.feature.mypage.component.MyPageButton
 import org.sopt.official.feature.mypage.component.MyPageTextField
 import org.sopt.official.feature.mypage.component.MyPageTopBar
 import org.sopt.official.feature.mypage.di.userRepository
 import org.sopt.official.feature.mypage.soptamp.state.rememberModifyProfileState
+import org.sopt.official.model.UserStatus
+import org.sopt.official.model.toViewType
 
 @AndroidEntryPoint
 class AdjustSentenceActivity : AppCompatActivity() {
 
+    private val args by serializableExtra(StartArgs(UserStatus.UNAUTHENTICATED.name))
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val userStatus = args?.userStatus?.let { UserStatus.of(it) } ?: UserStatus.UNAUTHENTICATED
+
         setContent {
             SoptTheme {
                 val context = LocalContext.current
+                val tracker = LocalTracker.current
+                val viewType = userStatus.toViewType()
+
                 val uiState = rememberModifyProfileState(
                     userRepository = userRepository,
                     onShowToast = { context.toast(it) }
@@ -94,7 +109,10 @@ class AdjustSentenceActivity : AppCompatActivity() {
                             modifier = Modifier
                                 .padding(20.dp)
                                 .fillMaxWidth(),
-                            onClick = uiState.onUpdate,
+                            onClick = {
+                                uiState.onUpdate()
+                                tracker.trackViewType(MypageAnalyticsEvent.CLICK_DONE_EDIT_STATUSMESSAGE, viewType)
+                            },
                             isEnabled = uiState.isConfirmed
                         ) {
                             Text(
@@ -108,8 +126,14 @@ class AdjustSentenceActivity : AppCompatActivity() {
         }
     }
 
+    data class StartArgs(
+        val userStatus: String,
+    ) : Serializable
+
     companion object {
         @JvmStatic
-        fun getIntent(context: Context) = Intent(context, AdjustSentenceActivity::class.java)
+        fun getIntent(context: Context, args: StartArgs) = Intent(context, AdjustSentenceActivity::class.java).apply {
+            putExtra("args", args)
+        }
     }
 }

--- a/feature/soptlog/build.gradle.kts
+++ b/feature/soptlog/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation(projects.core.localstorage)
     implementation(projects.core.navigation)
     implementation(projects.core.analytics)
+    implementation(projects.core.model)
 
     // domain
     implementation(projects.domain.appjamtamp)

--- a/feature/soptlog/src/main/java/SoptlogAnalytics.kt
+++ b/feature/soptlog/src/main/java/SoptlogAnalytics.kt
@@ -1,0 +1,9 @@
+import org.sopt.official.analytics.AnalyticsEvent
+import org.sopt.official.analytics.EventType
+
+enum class SoptlogAnalyticsEvent(
+    override val type : EventType,
+    override val eventName : String
+):AnalyticsEvent {
+    VIEW_SOPTLOG_MAIN(EventType.VIEW,"soptlog_main"),
+}

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogScreen.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogScreen.kt
@@ -54,6 +54,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.toImmutableList
 import org.sopt.official.analytics.EventType
 import org.sopt.official.analytics.compose.LocalTracker
+import org.sopt.official.analytics.trackViewType
 import org.sopt.official.common.util.throttledNoRippleClickable
 import org.sopt.official.designsystem.SoptTheme
 import org.sopt.official.designsystem.component.dialog.NetworkErrorDialog
@@ -65,10 +66,13 @@ import org.sopt.official.feature.soptlog.model.MySoptLogItemType
 import org.sopt.official.feature.soptlog.model.SoptLogCategory
 import org.sopt.official.feature.soptlog.navigation.SoptLogNavigation
 import org.sopt.official.feature.soptlog.state.SoptLogNavigationEvent
+import org.sopt.official.model.UserStatus
+import org.sopt.official.model.toViewType
 
 @Composable
 internal fun SoptLogRoute(
     soptLogNavigation: SoptLogNavigation,
+    userStatus: UserStatus,
     navigateToFortune: () -> Unit = {},
     navigateUp: () -> Unit = {},
     viewModel: SoptLogViewModel = hiltViewModel()
@@ -102,6 +106,11 @@ internal fun SoptLogRoute(
     val isAppjamMode by viewModel.isAppjamMode.collectAsStateWithLifecycle()
     val todayFortuneText by viewModel.todayFortuneText.collectAsStateWithLifecycle("")
     val tracker = LocalTracker.current
+    val viewType = userStatus.toViewType()
+
+    LaunchedEffect(Unit) {
+        tracker.trackViewType(SoptlogAnalyticsEvent.VIEW_SOPTLOG_MAIN, viewType)
+    }
 
     when {
         soptLogState.isLoading -> LoadingIndicator()

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptlogAnalytics.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptlogAnalytics.kt
@@ -1,3 +1,5 @@
+package org.sopt.official.feature.soptlog
+
 import org.sopt.official.analytics.AnalyticsEvent
 import org.sopt.official.analytics.EventType
 

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/navigation/SoptlogNavigator.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/navigation/SoptlogNavigator.kt
@@ -31,6 +31,7 @@ import androidx.navigation.compose.composable
 import kotlinx.serialization.Serializable
 import org.sopt.official.core.navigation.Route
 import org.sopt.official.feature.soptlog.SoptLogRoute
+import org.sopt.official.model.UserStatus
 
 @Serializable
 data object SoptLog : Route
@@ -40,12 +41,14 @@ fun NavController.navigateToSoptLog(navOptions: NavOptions) {
 }
 
 fun NavGraphBuilder.soptLogNavGraph(
+    userStatus: UserStatus,
     soptLogNavigation: SoptLogNavigation,
     navigateToFortune: () -> Unit,
     navigateUp: () -> Unit
 ) {
     composable<SoptLog> {
         SoptLogRoute(
+            userStatus = userStatus,
             soptLogNavigation = soptLogNavigation,
             navigateToFortune = navigateToFortune,
             navigateUp = navigateUp


### PR DESCRIPTION
## Related issue 🛠
- closed #1629 

## Work Description ✏️
- 마이페이지 이벤트 10건 추가
- 솝트로그 이벤트 1건 추가

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] Task1

## To Reviewers 📢
- 화면진입 관련 이벤트는 기존화면들 처럼 LaunchedEffect 를 통해 추가했습니다. 솝트로그는 독립된 모듈로 관리되고 있어 'view_soptlog_main' 해당 이벤트만 soptlogAnalytics 를 통해 관리하게 작업했스니다.