### PR TITLE
[HOTFIX/#1635] 마이페이지 개편 전 임시 폴백 처리 및 솝트로그 탭 통합

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -103,6 +103,13 @@
             android:exported="false"
             android:launchMode="singleTop" />
         <activity
+            android:name=".feature.mypage.legacy.LegacyMyPageActivity"
+            android:exported="false"
+            android:launchMode="singleTop" />
+        <activity
+            android:name=".feature.mypage.legacy.LegacySignOutActivity"
+            android:exported="false" />
+        <activity
             android:name=".feature.mypage.signout.SignOutActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/java/org/sopt/official/feature/navigator/NavigatorProviderIntent.kt
+++ b/app/src/main/java/org/sopt/official/feature/navigator/NavigatorProviderIntent.kt
@@ -34,6 +34,7 @@ import org.sopt.official.feature.attendance.AttendanceActivity
 import org.sopt.official.feature.auth.AuthActivity
 import org.sopt.official.feature.fortune.FortuneActivity
 import org.sopt.official.feature.main.MainActivity
+import org.sopt.official.feature.mypage.legacy.LegacyMyPageActivity
 import org.sopt.official.feature.mypage.soptamp.ui.AdjustSentenceActivity
 import org.sopt.official.feature.notification.SchemeActivity
 import org.sopt.official.feature.notification.all.NotificationActivity
@@ -51,6 +52,9 @@ class NavigatorProviderIntent @Inject constructor(
         context,
         notificationId
     )
+
+    override fun getLegacyMyPageActivityIntent(userStatus: UserStatus): Intent =
+        LegacyMyPageActivity.getIntent(context, userStatus)
 
     override fun getAdjustSentenceActivityIntent(userStatus: UserStatus): Intent = AdjustSentenceActivity.getIntent(
         context,

--- a/core/common/src/main/java/org/sopt/official/common/navigator/NavigatorProvider.kt
+++ b/core/common/src/main/java/org/sopt/official/common/navigator/NavigatorProvider.kt
@@ -34,6 +34,7 @@ interface NavigatorProvider {
     fun getAuthActivityIntent(): Intent
     fun getNotificationActivityIntent(): Intent
     fun getNotificationDetailActivityIntent(notificationId: String): Intent
+    fun getLegacyMyPageActivityIntent(userStatus: UserStatus): Intent
     fun getAdjustSentenceActivityIntent(userStatus: UserStatus): Intent
     fun getAttendanceActivityIntent(): Intent
     fun getSoptampActivityIntent(): Intent

--- a/feature/home/src/main/java/org/sopt/official/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/HomeRoute.kt
@@ -220,6 +220,7 @@ private fun HomeScreenForMember(
                     homeDashboardNavigation.navigateToNotification()
                     tracker.trackViewType(HomeAnalyticsEvent.CLICK_ALARM, viewType)
                 },
+                onSettingClick = homeDashboardNavigation::navigateToLegacyMyPage,
                 modifier = Modifier
                     .padding(horizontal = 20.dp)
             )
@@ -402,7 +403,7 @@ private fun HomeScreenForVisitor(
             .padding(horizontal = 20.dp),
     ) {
         Spacer(modifier = Modifier.height(height = 8.dp))
-        HomeTopBarForVisitor()
+        HomeTopBarForVisitor(onSettingClick = homeDashboardNavigation::navigateToLegacyMyPage)
         Spacer(modifier = Modifier.height(height = 16.dp))
         HomeUserSoptLogDashboardForVisitor(onDashboardClick = homeDashboardNavigation::navigateToEditProfile)
         Spacer(modifier = Modifier.height(height = 36.dp))

--- a/feature/home/src/main/java/org/sopt/official/feature/home/component/HomeTopBar.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/component/HomeTopBar.kt
@@ -45,12 +45,14 @@ import androidx.compose.ui.unit.dp
 import org.sopt.official.designsystem.SoptTheme
 import org.sopt.official.feature.home.R.drawable.ic_notification_off
 import org.sopt.official.feature.home.R.drawable.ic_notification_on
+import org.sopt.official.feature.home.R.drawable.ic_setting
 import org.sopt.official.feature.home.R.drawable.img_logo
 
 @Composable
 internal fun HomeTopBarForMember(
     hasNotification: Boolean,
     onNotificationClick: () -> Unit,
+    onSettingClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     HomeTopBar(modifier = modifier) {
@@ -62,6 +64,12 @@ internal fun HomeTopBarForMember(
             tint = Unspecified,
             modifier = Modifier.clickable(onClick = onNotificationClick),
         )
+        Icon(
+            imageVector = ImageVector.vectorResource(ic_setting),
+            contentDescription = "마이페이지",
+            tint = Unspecified,
+            modifier = Modifier.clickable(onClick = onSettingClick),
+        )
     }
 }
 
@@ -72,22 +80,31 @@ private fun HomeTopBarForMemberPreview() {
         HomeTopBarForMember(
             hasNotification = true,
             onNotificationClick = {},
+            onSettingClick = {},
         )
     }
 }
 
 @Composable
 internal fun HomeTopBarForVisitor(
+    onSettingClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    HomeTopBar(modifier = modifier) {}
+    HomeTopBar(modifier = modifier) {
+        Icon(
+            imageVector = ImageVector.vectorResource(ic_setting),
+            contentDescription = "마이페이지",
+            tint = Unspecified,
+            modifier = Modifier.clickable(onClick = onSettingClick),
+        )
+    }
 }
 
 @Preview
 @Composable
 private fun HomeTopBarForVisitorPreview() {
     SoptTheme {
-        HomeTopBarForVisitor()
+        HomeTopBarForVisitor(onSettingClick = {})
     }
 }
 

--- a/feature/home/src/main/java/org/sopt/official/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/org/sopt/official/feature/home/navigation/HomeNavigation.kt
@@ -45,6 +45,7 @@ sealed interface HomeNavigation {
     @Stable
     interface HomeDashboardNavigation : HomeNavigation {
         fun navigateToNotification()
+        fun navigateToLegacyMyPage()
         fun navigateToSchedule()
         fun navigateToEditProfile()
         fun navigateToAttendance()

--- a/feature/main/src/main/java/org/sopt/official/feature/main/MainNavigator.kt
+++ b/feature/main/src/main/java/org/sopt/official/feature/main/MainNavigator.kt
@@ -41,6 +41,7 @@ import org.sopt.official.feature.mypage.navigation.MyPageGraph
 import org.sopt.official.feature.mypage.navigation.navigateToMyPage
 import org.sopt.official.feature.poke.navigation.PokeGraph
 import org.sopt.official.feature.poke.navigation.navigateToPokeEntry
+import org.sopt.official.feature.soptlog.navigation.navigateToSoptLog
 import org.sopt.official.model.UserStatus
 import org.sopt.official.stamp.feature.navigation.navigateToSoptamp
 
@@ -106,6 +107,12 @@ class MainNavigator(
                     navOptions = navOptions
                 )
             }
+
+            MainTab.SoptLog -> {
+                navController.navigateToSoptLog(
+                    navOptions = navOptions
+                )
+            }
         }
     }
 
@@ -153,6 +160,14 @@ class MainNavigator(
                 navController.navigateToMyPage(
                     navOptions = navOptions {
                         popUpTo<MyPageGraph> { inclusive = true }
+                        launchSingleTop = true
+                    }
+                )
+            }
+
+            MainTab.SoptLog -> {
+                navController.navigateToSoptLog(
+                    navOptions = navOptions {
                         launchSingleTop = true
                     }
                 )

--- a/feature/main/src/main/java/org/sopt/official/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/org/sopt/official/feature/main/MainScreen.kt
@@ -207,13 +207,12 @@ fun MainScreen(
         }
 
         if (shouldNavigateToMyPage) {
-            navigator.navigate(MainTab.MyPage, userStatus)
+            context.startActivity(applicationNavigator.getLegacyMyPageActivityIntent(userStatus))
             activity?.intent?.putExtra("isMyPageDeepLink", false)
         }
 
         if (shouldNavigateToSoptLog) {
-            navigator.navigate(MainTab.MyPage, userStatus)
-            navigator.navController.navigate(SoptLog)
+            navigator.navigate(MainTab.SoptLog, userStatus)
             activity?.intent?.putExtra("isSoptLogDeepLink", false)
         }
 
@@ -282,6 +281,9 @@ fun MainScreen(
 
                                 override fun navigateToNotification() =
                                     context.startActivity(applicationNavigator.getNotificationActivityIntent())
+
+                                override fun navigateToLegacyMyPage() =
+                                    context.startActivity(applicationNavigator.getLegacyMyPageActivityIntent(userStatus))
 
                                 override fun navigateToSchedule() = context.startActivity(applicationNavigator.getScheduleActivityIntent())
                                 override fun navigateToEditProfile() {
@@ -355,6 +357,7 @@ fun MainScreen(
                             userStatus = userStatus
                         )
 
+                        // Keep the redesigned graph compiled while release entry points use legacy MyPage.
                         myPageNavGraph(
                             userStatus = userStatus,
                             navigateToSoptLog = {
@@ -369,43 +372,42 @@ fun MainScreen(
                                 }
                                 context.startActivity(intent)
                             }
-                        ) {
-                            soptLogNavGraph(
-                                userStatus = userStatus,
-                                soptLogNavigation = object : SoptLogNavigation {
-                                    override fun navigateToDeepLink(url: String) {
-                                        if (userStatus == UserStatus.UNAUTHENTICATED) isOpenDialog = true
-                                        else if (url == DeepLinkType.SOPTAMP.link) {
-                                            navigator.navigate(MainTab.Soptamp, userStatus)
-                                        } else {
-                                            context.startActivity(DeepLinkType.of(url).getIntent(context, userStatus, url))
+                        )
+
+                        soptLogNavGraph(
+                            userStatus = userStatus,
+                            soptLogNavigation = object : SoptLogNavigation {
+                                override fun navigateToDeepLink(url: String) {
+                                    if (userStatus == UserStatus.UNAUTHENTICATED) isOpenDialog = true
+                                    else if (url == DeepLinkType.SOPTAMP.link) {
+                                        navigator.navigate(MainTab.Soptamp, userStatus)
+                                    } else {
+                                        context.startActivity(DeepLinkType.of(url).getIntent(context, userStatus, url))
+                                    }
+                                }
+
+                                override fun navigateToPoke(url: String, isNewPoke: Boolean, currentDestination: Int, friendType: String?) {
+                                    when {
+                                        url.contains("home/poke/friend-list-summary") -> {
+                                            navigator.navController.navigateToPokeFriendList(friendType, null)
+                                        }
+
+                                        isNewPoke -> {
+                                            navigator.navController.navigateToPokeOnboarding(currentDestination, userStatus.name)
+                                        }
+
+                                        else -> {
+                                            navigator.navigate(MainTab.Poke, userStatus)
                                         }
                                     }
-
-                                    override fun navigateToPoke(url: String, isNewPoke: Boolean, currentDestination: Int, friendType: String?) {
-                                        when {
-                                            url.contains("home/poke/friend-list-summary") -> {
-                                                navigator.navController.navigateToPokeFriendList(friendType, null)
-                                            }
-
-                                            isNewPoke -> {
-                                                navigator.navController.navigateToPokeOnboarding(currentDestination, userStatus.name)
-                                            }
-
-                                            else -> {
-                                                navigator.navigate(MainTab.Poke, userStatus)
-                                            }
-                                        }
-                                    }
-                                },
-                                navigateToFortune = {
-                                    context.startActivity(
-                                        applicationNavigator.getFortuneActivityIntent()
-                                    )
-                                },
-                                navigateUp = navigator::navigateUp
-                            )
-                        }
+                                }
+                            },
+                            navigateToFortune = {
+                                context.startActivity(
+                                    applicationNavigator.getFortuneActivityIntent()
+                                )
+                            }
+                        )
 
                         sopletterGraph(
                             userStatus = userStatus,

--- a/feature/main/src/main/java/org/sopt/official/feature/main/MainTab.kt
+++ b/feature/main/src/main/java/org/sopt/official/feature/main/MainTab.kt
@@ -31,6 +31,7 @@ import org.sopt.official.core.navigation.MainTabRoute
 import org.sopt.official.core.navigation.Route
 import org.sopt.official.feature.appjamtamp.navigation.AppjamtampNavGraph
 import org.sopt.official.feature.mypage.navigation.MyPageGraph
+import org.sopt.official.feature.soptlog.navigation.SoptLog as SoptLogRoute
 
 enum class MainTab(
     @param:DrawableRes val icon: Int,
@@ -77,6 +78,14 @@ enum class MainTab(
         route = MyPageGraph,
         loggingName = "navi_mypage",
         deeplink = null
+    ),
+
+    SoptLog(
+        icon = R.drawable.ic_main_soptlog,
+        contentDescription = "솝트로그",
+        route = SoptLogRoute,
+        loggingName = "navi_soptlog",
+        deeplink = "soptlog"
     );
 
     companion object {
@@ -95,10 +104,11 @@ enum class MainTab(
 
         fun getActiveTabs(activeServices: List<String?>): List<MainTab> {
             val activeServices = entries.filter { tab ->
-                tab.deeplink != null && activeServices.contains(tab.deeplink)
+                tab != MyPage && tab != SoptLog &&
+                    tab.deeplink != null && activeServices.contains(tab.deeplink)
             }
 
-            return listOf(Home) + activeServices + listOf(MyPage)
+            return listOf(Home) + activeServices + listOf(SoptLog)
         }
     }
 }

--- a/feature/mypage/build.gradle.kts
+++ b/feature/mypage/build.gradle.kts
@@ -34,6 +34,7 @@ android {
 }
 
 dependencies {
+    implementation(projects.domain.appjamtamp)
     implementation(projects.domain.auth)
     implementation(projects.domain.soptamp)
     implementation(projects.domain.soptlog)

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/MyPageContract.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/MyPageContract.kt
@@ -35,6 +35,7 @@ data class MyPageState(
     val name: String = "",
     val profileImage: String = "",
     val part: String = "",
+    val isAppjamJoined: Boolean = false,
     val soptampCount: Int? = null,
     val totalPokeCount: Int? = null,
 )

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/MyPageScreen.kt
@@ -272,6 +272,7 @@ internal fun MyPageScreen(
 
             MyPageUserContentsInfo(
                 userStatus = state.userStatus,
+                isAppjamJoined = state.isAppjamJoined,
                 totalSoptampCount = state.soptampCount,
                 totalPokeCount = state.totalPokeCount,
                 isAppjamPeriod = isAppjamMode,

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/MyPageViewModel.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
+import org.sopt.official.domain.appjamtamp.repository.AppjamtampRepository
 import org.sopt.official.domain.auth.repository.AuthRepository
 import org.sopt.official.domain.notification.repository.NotificationRepository
 import org.sopt.official.domain.soptamp.repository.StampRepository
@@ -58,6 +59,7 @@ class MyPageViewModel @Inject constructor(
     private val notificationRepository: NotificationRepository,
     private val soptUserRepository: SoptUserRepository,
     private val soptLogRepository: SoptLogRepository,
+    private val appjamtampRepository: AppjamtampRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(MyPageState())
@@ -73,6 +75,19 @@ class MyPageViewModel @Inject constructor(
         viewModelScope.launch {
             userStorage.userStatus.collect { status ->
                 _state.update { it.copy(userStatus = status) }
+            }
+        }
+        viewModelScope.launch {
+            userStorage.isAppjamMode.collect { isAppjamMode ->
+                if (isAppjamMode) {
+                    appjamtampRepository.getMyAppjamInfo()
+                        .onSuccess { info ->
+                            _state.update { it.copy(isAppjamJoined = info.isAppjamJoined) }
+                        }
+                        .onFailure(Timber::e)
+                } else {
+                    _state.update { it.copy(isAppjamJoined = false) }
+                }
             }
         }
         viewModelScope.launch {

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/component/MyPageUserContentsInfo.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/component/MyPageUserContentsInfo.kt
@@ -30,6 +30,7 @@ internal fun MyPageUserContentsInfo(
     userStatus: UserStatus,
     modifier: Modifier = Modifier,
     isAppjamPeriod : Boolean = false,
+    isAppjamJoined: Boolean = false,
     totalSoptampCount: Int? = 0,
     totalPokeCount: Int? = 0,
 ) {
@@ -42,8 +43,8 @@ internal fun MyPageUserContentsInfo(
             )
             .padding(horizontal = 6.dp, vertical = 4.dp)
     ) {
-        // 활동 기수이면서 앱잼 탬프 기간이 아니라면 보이기
-        if (userStatus == UserStatus.ACTIVE && !isAppjamPeriod) {
+        val showSoptampLog = userStatus == UserStatus.ACTIVE || (isAppjamPeriod && isAppjamJoined)
+        if (showSoptampLog) {
             MyPageUserContentsInfoItem(
                 icon = R.drawable.ic_mypage_soptamp,
                 infoTitleText = "솝탬프",

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/di/EntryPoint.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/di/EntryPoint.kt
@@ -40,7 +40,8 @@ import org.sopt.official.domain.user.repository.SoptUserRepository
 internal interface AuthEntryPoint {
     fun authRepository(): AuthRepository
     fun userRepository(): UserRepository
-
+    fun stampRepository(): StampRepository
+    fun notificationRepository(): NotificationRepository
     fun soptUserRepository(): SoptUserRepository
 }
 
@@ -54,6 +55,18 @@ internal val userRepository by lazy {
     EntryPointAccessors
         .fromApplication(appContext, AuthEntryPoint::class.java)
         .userRepository()
+}
+
+internal val stampRepository by lazy {
+    EntryPointAccessors
+        .fromApplication(appContext, AuthEntryPoint::class.java)
+        .stampRepository()
+}
+
+internal val notificationRepository by lazy {
+    EntryPointAccessors
+        .fromApplication(appContext, AuthEntryPoint::class.java)
+        .notificationRepository()
 }
 
 internal val soptUserRepository by lazy {

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/legacy/LegacyMyPageActivity.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/legacy/LegacyMyPageActivity.kt
@@ -1,0 +1,224 @@
+package org.sopt.official.feature.mypage.legacy
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.Settings
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.google.firebase.messaging.FirebaseMessaging
+import dagger.hilt.android.AndroidEntryPoint
+import io.github.takahirom.rin.rememberRetained
+import javax.inject.Inject
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import org.sopt.official.common.navigator.NavigatorProvider
+import org.sopt.official.designsystem.SoptTheme
+import org.sopt.official.domain.auth.repository.AuthRepository
+import org.sopt.official.domain.notification.repository.NotificationRepository
+import org.sopt.official.domain.soptamp.repository.StampRepository
+import org.sopt.official.feature.mypage.component.MyPageSection
+import org.sopt.official.feature.mypage.component.MyPageTopBar
+import org.sopt.official.feature.mypage.di.authRepository
+import org.sopt.official.feature.mypage.di.notificationRepository
+import org.sopt.official.feature.mypage.di.stampRepository
+import org.sopt.official.feature.mypage.model.MyPageDialogState
+import org.sopt.official.feature.mypage.model.MyPageUiModel
+import org.sopt.official.feature.mypage.soptamp.ui.AdjustSentenceActivity
+import org.sopt.official.feature.mypage.web.WebUrlConstant
+import org.sopt.official.model.UserStatus
+import timber.log.Timber
+
+/** Temporary fallback isolated for removal after the redesigned MyPage is enabled again. */
+@AndroidEntryPoint
+class LegacyMyPageActivity : AppCompatActivity() {
+    @Inject
+    lateinit var navigatorProvider: NavigatorProvider
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val userStatus = intent.getStringExtra(EXTRA_USER_STATUS)
+            ?.let(UserStatus::of)
+            ?: UserStatus.UNAUTHENTICATED
+
+        setContent {
+            SoptTheme {
+                LegacyMyPageRoute(
+                    userStatus = userStatus,
+                    authRepository = authRepository,
+                    stampRepository = stampRepository,
+                    notificationRepository = notificationRepository,
+                    onRestartApp = { startActivity(navigatorProvider.getAuthActivityIntent()) },
+                    onBack = onBackPressedDispatcher::onBackPressed,
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_USER_STATUS = "legacy_mypage_user_status"
+
+        fun getIntent(context: Context, userStatus: UserStatus): Intent =
+            Intent(context, LegacyMyPageActivity::class.java)
+                .putExtra(EXTRA_USER_STATUS, userStatus.name)
+    }
+}
+
+@Composable
+private fun LegacyMyPageRoute(
+    userStatus: UserStatus,
+    authRepository: AuthRepository,
+    stampRepository: StampRepository,
+    notificationRepository: NotificationRepository,
+    onRestartApp: () -> Unit,
+    onBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val scrollState = rememberScrollState()
+    var dialogState by rememberRetained { mutableStateOf(MyPageDialogState.CLEAR) }
+
+    val serviceSectionItems = remember {
+        persistentListOf(
+            MyPageUiModel.Header(title = "서비스 이용 방침"),
+            MyPageUiModel.MyPageItem(title = "개인정보 처리 방침") {
+                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(WebUrlConstant.NOTICE_PRIVATE_INFO)))
+            },
+            MyPageUiModel.MyPageItem(title = "서비스 이용약관") {
+                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(WebUrlConstant.NOTICE_SERVICE_RULE)))
+            },
+            MyPageUiModel.MyPageItem(title = "의견 보내기") {
+                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(WebUrlConstant.OPINION_KAKAO_CHAT)))
+            },
+        )
+    }
+    val notificationSectionItems = remember {
+        persistentListOf(
+            MyPageUiModel.Header(title = "알림 설정"),
+            MyPageUiModel.MyPageItem(title = "알림 설정하기") {
+                context.startActivity(
+                    Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                        .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                )
+            },
+        )
+    }
+    val soptampSectionItems = remember {
+        persistentListOf(
+            MyPageUiModel.Header(title = "솝탬프 설정"),
+            MyPageUiModel.MyPageItem(title = "한 마디 편집") {
+                context.startActivity(AdjustSentenceActivity.getIntent(context))
+            },
+            MyPageUiModel.MyPageItem(title = "스탬프 초기화") {
+                dialogState = MyPageDialogState.CLEAR_SOPTAMP
+            },
+        )
+    }
+    val etcSectionItems = remember {
+        persistentListOf(
+            MyPageUiModel.Header(title = "기타"),
+            MyPageUiModel.MyPageItem(title = "로그아웃") {
+                dialogState = MyPageDialogState.REQUEST_LOGOUT
+            },
+            MyPageUiModel.MyPageItem(title = "탈퇴하기") {
+                context.startActivity(LegacySignOutActivity.getIntent(context))
+            },
+        )
+    }
+    val loginSectionItems = remember {
+        persistentListOf(
+            MyPageUiModel.Header(title = "기타"),
+            MyPageUiModel.MyPageItem(title = "로그인", onItemClick = onRestartApp),
+        )
+    }
+
+    Scaffold(
+        modifier = Modifier
+            .background(SoptTheme.colors.background)
+            .fillMaxSize(),
+        topBar = { MyPageTopBar(title = "마이페이지", onNavigationIconClick = onBack) },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .background(SoptTheme.colors.background)
+                .verticalScroll(scrollState),
+        ) {
+            Spacer(modifier = Modifier.height(20.dp))
+            MyPageSection(items = serviceSectionItems)
+            Spacer(modifier = Modifier.height(16.dp))
+            when (userStatus) {
+                UserStatus.ACTIVE, UserStatus.INACTIVE -> {
+                    MyPageSection(items = notificationSectionItems)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    MyPageSection(items = soptampSectionItems)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    MyPageSection(items = etcSectionItems)
+                }
+
+                UserStatus.UNAUTHENTICATED -> MyPageSection(items = loginSectionItems)
+            }
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+
+        when (dialogState) {
+            MyPageDialogState.CLEAR_SOPTAMP -> LegacyMyPageDialog(
+                onDismissRequest = { dialogState = MyPageDialogState.CLEAR },
+                title = "미션을 초기화 하실건가요?",
+                subTitle = "사진, 메모가 삭제되고\n전체 미션이 미완료상태로 초기화됩니다.",
+                negativeText = "취소",
+                positiveText = "초기화",
+                onPositiveButtonClick = {
+                    scope.launch {
+                        stampRepository.deleteAllStamps()
+                            .onSuccess { dialogState = MyPageDialogState.CLEAR }
+                            .onFailure(Timber::e)
+                    }
+                },
+            )
+
+            MyPageDialogState.REQUEST_LOGOUT -> LegacyMyPageDialog(
+                onDismissRequest = { dialogState = MyPageDialogState.CLEAR },
+                title = "로그아웃",
+                subTitle = "정말 로그아웃을 하실 건가요?",
+                negativeText = "취소",
+                positiveText = "로그아웃",
+                onPositiveButtonClick = {
+                    scope.launch {
+                        runCatching {
+                            notificationRepository.deleteToken(FirebaseMessaging.getInstance().token.await())
+                        }.onFailure(Timber::e)
+                        withContext(Dispatchers.IO) { authRepository.clearUserToken() }
+                        onRestartApp()
+                    }
+                },
+            )
+
+            MyPageDialogState.CLEAR -> Unit
+        }
+    }
+}

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/legacy/LegacyMyPageDialog.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/legacy/LegacyMyPageDialog.kt
@@ -1,0 +1,98 @@
+package org.sopt.official.feature.mypage.legacy
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import org.sopt.official.designsystem.Gray10
+import org.sopt.official.designsystem.Gray100
+import org.sopt.official.designsystem.Gray600
+import org.sopt.official.designsystem.Gray700
+import org.sopt.official.designsystem.SoptTheme
+import org.sopt.official.designsystem.White
+import org.sopt.official.feature.mypage.component.MyPageButton
+
+/** Exact visual fallback of the dialog used before the MyPage redesign. */
+@Composable
+internal fun LegacyMyPageDialog(
+    onDismissRequest: () -> Unit,
+    title: String,
+    subTitle: String,
+    negativeText: String,
+    positiveText: String,
+    modifier: Modifier = Modifier,
+    properties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false),
+    onPositiveButtonClick: () -> Unit = {},
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = properties,
+    ) {
+        Column(
+            modifier = modifier
+                .padding(horizontal = 25.dp)
+                .background(
+                    color = Gray700,
+                    shape = RoundedCornerShape(10.dp),
+                )
+                .padding(top = 26.dp, bottom = 12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = title,
+                color = White,
+                style = SoptTheme.typography.heading16B,
+            )
+            Spacer(modifier = Modifier.height(28.dp))
+            Text(
+                text = subTitle,
+                color = Gray100,
+                style = SoptTheme.typography.body14M,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(34.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 7.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                MyPageButton(
+                    modifier = Modifier.weight(1f),
+                    paddingVertical = 9.dp,
+                    onClick = onDismissRequest,
+                    containerColor = Gray600,
+                    contentColor = Gray10,
+                ) {
+                    Text(
+                        text = negativeText,
+                        style = SoptTheme.typography.body14M,
+                    )
+                }
+                MyPageButton(
+                    modifier = Modifier.weight(1f),
+                    paddingVertical = 9.dp,
+                    onClick = onPositiveButtonClick,
+                ) {
+                    Text(
+                        text = positiveText,
+                        style = SoptTheme.typography.body14M,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/legacy/LegacySignOutActivity.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/legacy/LegacySignOutActivity.kt
@@ -1,0 +1,100 @@
+package org.sopt.official.feature.mypage.legacy
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.jakewharton.processphoenix.ProcessPhoenix
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import org.sopt.official.designsystem.Gray300
+import org.sopt.official.designsystem.SoptTheme
+import org.sopt.official.designsystem.White
+import org.sopt.official.feature.mypage.R
+import org.sopt.official.feature.mypage.component.MyPageButton
+import org.sopt.official.feature.mypage.component.MyPageTopBar
+import org.sopt.official.feature.mypage.di.authRepository
+
+/** Exact behavioral fallback of the withdrawal screen used before the MyPage redesign. */
+@AndroidEntryPoint
+class LegacySignOutActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            SoptTheme {
+                val scope = rememberCoroutineScope()
+
+                Scaffold(
+                    modifier = Modifier
+                        .background(SoptTheme.colors.background)
+                        .fillMaxSize(),
+                    topBar = {
+                        MyPageTopBar(
+                            title = "마이페이지",
+                            onNavigationIconClick = onBackPressedDispatcher::onBackPressed,
+                        )
+                    },
+                ) { innerPadding ->
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                            .background(SoptTheme.colors.background),
+                    ) {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = stringResource(R.string.sign_out_title),
+                            color = White,
+                            style = SoptTheme.typography.heading16B,
+                            modifier = Modifier.padding(start = 20.dp),
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = stringResource(R.string.sign_out_subtitle),
+                            color = Gray300,
+                            style = SoptTheme.typography.body14R,
+                            modifier = Modifier.padding(horizontal = 20.dp),
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                        MyPageButton(
+                            paddingVertical = 16.dp,
+                            modifier = Modifier
+                                .padding(20.dp)
+                                .fillMaxWidth(),
+                            onClick = {
+                                scope.launch {
+                                    authRepository.clearUserToken()
+                                    ProcessPhoenix.triggerRebirth(this@LegacySignOutActivity)
+                                }
+                            },
+                        ) {
+                            Text(
+                                text = stringResource(R.string.sign_out_button),
+                                style = SoptTheme.typography.heading18B,
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(14.dp))
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun getIntent(context: Context): Intent = Intent(context, LegacySignOutActivity::class.java)
+    }
+}

--- a/feature/mypage/src/main/java/org/sopt/official/feature/mypage/soptamp/ui/AdjustSentenceActivity.kt
+++ b/feature/mypage/src/main/java/org/sopt/official/feature/mypage/soptamp/ui/AdjustSentenceActivity.kt
@@ -44,7 +44,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.Serializable
+import javax.inject.Inject
+import org.sopt.official.analytics.Tracker
 import org.sopt.official.analytics.compose.LocalTracker
+import org.sopt.official.analytics.compose.ProvideTracker
 import org.sopt.official.analytics.trackViewType
 import org.sopt.official.common.util.serializableExtra
 import org.sopt.official.common.view.toast
@@ -62,6 +65,9 @@ import org.sopt.official.model.toViewType
 @AndroidEntryPoint
 class AdjustSentenceActivity : AppCompatActivity() {
 
+    @Inject
+    lateinit var analyticsTracker: Tracker
+
     private val args by serializableExtra(StartArgs(UserStatus.UNAUTHENTICATED.name))
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -71,54 +77,56 @@ class AdjustSentenceActivity : AppCompatActivity() {
 
         setContent {
             SoptTheme {
-                val context = LocalContext.current
-                val tracker = LocalTracker.current
-                val viewType = userStatus.toViewType()
+                ProvideTracker(analyticsTracker) {
+                    val context = LocalContext.current
+                    val tracker = LocalTracker.current
+                    val viewType = userStatus.toViewType()
 
-                val uiState = rememberModifyProfileState(
-                    userRepository = userRepository,
-                    onShowToast = { context.toast(it) }
-                )
+                    val uiState = rememberModifyProfileState(
+                        userRepository = userRepository,
+                        onShowToast = { context.toast(it) }
+                    )
 
-                Scaffold(
-                    modifier = Modifier
-                        .background(SoptTheme.colors.background)
-                        .fillMaxSize(),
-                    topBar = {
-                        MyPageTopBar(
-                            title = "한 마디 편집",
-                            onNavigationIconClick = { onBackPressedDispatcher.onBackPressed() }
-                        )
-                    }
-                ) { innerPadding ->
-                    Column(
+                    Scaffold(
                         modifier = Modifier
-                            .fillMaxSize()
-                            .padding(innerPadding)
                             .background(SoptTheme.colors.background)
-                    ) {
-                        Spacer(modifier = Modifier.height(20.dp))
-                        MyPageTextField(
-                            sentence = uiState.current,
-                            modifier = Modifier.padding(horizontal = 20.dp),
-                            onTextChange = { uiState.onChangeCurrent(it) },
-                        )
-                        Spacer(modifier = Modifier.height(32.dp))
-                        MyPageButton(
-                            paddingVertical = 16.dp,
-                            modifier = Modifier
-                                .padding(20.dp)
-                                .fillMaxWidth(),
-                            onClick = {
-                                uiState.onUpdate()
-                                tracker.trackViewType(MypageAnalyticsEvent.CLICK_DONE_EDIT_STATUSMESSAGE, viewType)
-                            },
-                            isEnabled = uiState.isConfirmed
-                        ) {
-                            Text(
-                                text = stringResource(R.string.adjust_sentence_button),
-                                style = SoptTheme.typography.heading18B
+                            .fillMaxSize(),
+                        topBar = {
+                            MyPageTopBar(
+                                title = "한 마디 편집",
+                                onNavigationIconClick = { onBackPressedDispatcher.onBackPressed() }
                             )
+                        }
+                    ) { innerPadding ->
+                        Column(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(innerPadding)
+                                .background(SoptTheme.colors.background)
+                        ) {
+                            Spacer(modifier = Modifier.height(20.dp))
+                            MyPageTextField(
+                                sentence = uiState.current,
+                                modifier = Modifier.padding(horizontal = 20.dp),
+                                onTextChange = { uiState.onChangeCurrent(it) },
+                            )
+                            Spacer(modifier = Modifier.height(32.dp))
+                            MyPageButton(
+                                paddingVertical = 16.dp,
+                                modifier = Modifier
+                                    .padding(20.dp)
+                                    .fillMaxWidth(),
+                                onClick = {
+                                    uiState.onUpdate()
+                                    tracker.trackViewType(MypageAnalyticsEvent.CLICK_DONE_EDIT_STATUSMESSAGE, viewType)
+                                },
+                                isEnabled = uiState.isConfirmed
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.adjust_sentence_button),
+                                    style = SoptTheme.typography.heading18B
+                                )
+                            }
                         }
                     }
                 }
@@ -131,6 +139,9 @@ class AdjustSentenceActivity : AppCompatActivity() {
     ) : Serializable
 
     companion object {
+        @JvmStatic
+        fun getIntent(context: Context) = Intent(context, AdjustSentenceActivity::class.java)
+
         @JvmStatic
         fun getIntent(context: Context, args: StartArgs) = Intent(context, AdjustSentenceActivity::class.java).apply {
             putExtra("args", args)

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogScreen.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogScreen.kt
@@ -36,14 +36,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.vectorResource
@@ -55,7 +53,6 @@ import kotlinx.collections.immutable.toImmutableList
 import org.sopt.official.analytics.EventType
 import org.sopt.official.analytics.compose.LocalTracker
 import org.sopt.official.analytics.trackViewType
-import org.sopt.official.common.util.throttledNoRippleClickable
 import org.sopt.official.designsystem.SoptTheme
 import org.sopt.official.designsystem.component.dialog.NetworkErrorDialog
 import org.sopt.official.designsystem.component.indicator.LoadingIndicator
@@ -74,7 +71,6 @@ internal fun SoptLogRoute(
     soptLogNavigation: SoptLogNavigation,
     userStatus: UserStatus,
     navigateToFortune: () -> Unit = {},
-    navigateUp: () -> Unit = {},
     viewModel: SoptLogViewModel = hiltViewModel()
 ) {
     LaunchedEffect(Unit) {
@@ -102,7 +98,6 @@ internal fun SoptLogRoute(
 
     val soptLogState by viewModel.soptLogInfo.collectAsStateWithLifecycle()
     val soptLogInfo = soptLogState.soptLogInfo
-    val isAppjamJoined by viewModel.isAppjamJoined.collectAsStateWithLifecycle()
     val isAppjamMode by viewModel.isAppjamMode.collectAsStateWithLifecycle()
     val todayFortuneText by viewModel.todayFortuneText.collectAsStateWithLifecycle("")
     val tracker = LocalTracker.current
@@ -122,7 +117,6 @@ internal fun SoptLogRoute(
             with(receiver = soptLogState.soptLogInfo) {
                 SoptlogScreen(
                     isAppjamMode = isAppjamMode,
-                    isAppjamJoined = isAppjamJoined,
                     soptLogInfo = soptLogInfo,
                     todayFortuneText = todayFortuneText,
                     onNavigationClick = viewModel::onNavigationClick,
@@ -132,8 +126,7 @@ internal fun SoptLogRoute(
                             name = "at36_soptlog_soptmadi",
                             type = EventType.CLICK
                         )
-                    },
-                    navigateUp = navigateUp
+                    }
                 )
             }
         }
@@ -144,13 +137,11 @@ internal fun SoptLogRoute(
 @Composable
 private fun SoptlogScreen(
     isAppjamMode: Boolean,
-    isAppjamJoined: Boolean,
     soptLogInfo: SoptLogInfo,
     todayFortuneText: String,
     onNavigationClick: (url: String) -> Unit,
     modifier: Modifier = Modifier,
-    navigateToFortune: () -> Unit = {},
-    navigateUp: () -> Unit = {}
+    navigateToFortune: () -> Unit = {}
 ) {
     val scrollState = rememberScrollState()
 
@@ -171,18 +162,6 @@ private fun SoptlogScreen(
                     style = SoptTheme.typography.body16M,
                 )
             },
-            navigationIcon = {
-                Icon(
-                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_soptlog_arrow_left),
-                    contentDescription = null,
-                    tint = Color.Unspecified,
-                    modifier = Modifier
-                        .throttledNoRippleClickable(
-                            onClick = navigateUp
-                        )
-                        .padding(start = 20.dp)
-                )
-            }
         )
 
         Spacer(modifier = Modifier.height(20.dp))
@@ -196,7 +175,7 @@ private fun SoptlogScreen(
         Spacer(modifier = Modifier.height(36.dp))
 
         SoptlogContents {
-            val showSoptampSection = if (isAppjamMode) isAppjamJoined else soptLogInfo.isActive
+            val showSoptampSection = !isAppjamMode && soptLogInfo.isActive
             if (showSoptampSection) {
                 SoptLogSection(
                     title = "솝탬프 로그",
@@ -284,7 +263,6 @@ private fun PreviewSoptlogScreen() {
 
         SoptlogScreen(
             isAppjamMode = false,
-            isAppjamJoined = false,
             soptLogInfo = soptLogInfo,
             todayFortuneText = "오늘의 운세",
             onNavigationClick = { url ->

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogViewModel.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/SoptLogViewModel.kt
@@ -29,7 +29,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -40,7 +39,6 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import org.sopt.official.domain.appjamtamp.repository.AppjamtampRepository
 import org.sopt.official.domain.poke.entity.ApiResult
 import org.sopt.official.domain.poke.entity.CheckNewInPoke
 import org.sopt.official.domain.poke.usecase.CheckNewInPokeUseCase
@@ -54,7 +52,6 @@ import timber.log.Timber
 @HiltViewModel
 class SoptLogViewModel @Inject constructor(
     private val soptLogRepository: SoptLogRepository,
-    private val appjamtampRepository: AppjamtampRepository,
     private val checkNewInPokeUseCase: CheckNewInPokeUseCase,
     private val userStorage: UserStorage,
 ) : ViewModel() {
@@ -64,10 +61,6 @@ class SoptLogViewModel @Inject constructor(
 
     val todayFortuneText = _soptLogInfo.map { it.soptLogInfo.todayFortuneText }
 
-    private val _isAppjamJoined = MutableStateFlow(false)
-    val isAppjamJoined: StateFlow<Boolean>
-        get() = _isAppjamJoined.asStateFlow()
-
     val isAppjamMode: StateFlow<Boolean> = userStorage.isAppjamMode
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
@@ -75,11 +68,7 @@ class SoptLogViewModel @Inject constructor(
     val navigationEvent = _navigationEvent.receiveAsFlow()
 
     fun loadSoptLogInfo() {
-        if (isAppjamMode.value) {
-            loadSoptLogWithAppjamInfo()
-        } else {
-            loadSoptLogInfoOnly()
-        }
+        loadSoptLogInfoOnly()
     }
 
     fun onNavigationClick(url: String) {
@@ -120,35 +109,6 @@ class SoptLogViewModel @Inject constructor(
                 .onFailure(Timber::e)
 
             _soptLogInfo.update { it.copy(isLoading = false) }
-        }
-    }
-
-    private fun loadSoptLogWithAppjamInfo() {
-        viewModelScope.launch {
-            _soptLogInfo.update { it.copy(isLoading = true) }
-
-            val soptLogDeferred = async { soptLogRepository.getSoptLogInfo() }
-            val appjamInfoDeferred = async { appjamtampRepository.getMyAppjamInfo() }
-
-            val soptLogResult = soptLogDeferred.await()
-            val appjamResult = appjamInfoDeferred.await()
-
-            if (soptLogResult.isSuccess && appjamResult.isSuccess) {
-                _isAppjamJoined.value = appjamResult.getOrThrow().isAppjamJoined
-                _soptLogInfo.update {
-                    it.copy(
-                        soptLogInfo = soptLogResult.getOrThrow(),
-                        isLoading = false,
-                        isError = false
-                    )
-                }
-            } else {
-                val error = soptLogResult.exceptionOrNull()
-                    ?: appjamResult.exceptionOrNull()
-                    ?: Exception("Unknown error")
-                Timber.e(error)
-                _soptLogInfo.update { it.copy(isLoading = false, isError = true) }
-            }
         }
     }
 

--- a/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/navigation/SoptlogNavigator.kt
+++ b/feature/soptlog/src/main/java/org/sopt/official/feature/soptlog/navigation/SoptlogNavigator.kt
@@ -29,12 +29,12 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import kotlinx.serialization.Serializable
-import org.sopt.official.core.navigation.Route
+import org.sopt.official.core.navigation.MainTabRoute
 import org.sopt.official.feature.soptlog.SoptLogRoute
 import org.sopt.official.model.UserStatus
 
 @Serializable
-data object SoptLog : Route
+data object SoptLog : MainTabRoute
 
 fun NavController.navigateToSoptLog(navOptions: NavOptions) {
     navigate(SoptLog, navOptions)
@@ -43,15 +43,13 @@ fun NavController.navigateToSoptLog(navOptions: NavOptions) {
 fun NavGraphBuilder.soptLogNavGraph(
     userStatus: UserStatus,
     soptLogNavigation: SoptLogNavigation,
-    navigateToFortune: () -> Unit,
-    navigateUp: () -> Unit
+    navigateToFortune: () -> Unit
 ) {
     composable<SoptLog> {
         SoptLogRoute(
             userStatus = userStatus,
             soptLogNavigation = soptLogNavigation,
-            navigateToFortune = navigateToFortune,
-            navigateUp = navigateUp
+            navigateToFortune = navigateToFortune
         )
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #1635

## Work Description ✏️
- Lagacy Activity 제작하여 폴백용으로 유지
- 솝트로그 메인탭으로 추가
- HomeTopBar 에 설정 아이콘 추가
- 릴리즈 앱과 정책을 동일하게 맞춘 임시 로직

## Screenshot 📸
https://github.com/user-attachments/assets/dda849e0-a4ca-4cf8-9659-61eae8e86ca4


## Uncompleted Tasks 😅
- [ ] 마이페이지 QA

## To Reviewers 📢
마이페이지 QA 사항을 확인한 결과 수정 작업이 조금 필요할거 같아,
임시로 이전 기능이 그대로 동작하도록 수정작업을 했습니다.