### PR TITLE
[FEAT/#1649] 알림 권한 요청 로직 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -146,7 +146,7 @@
             android:launchMode="singleTop" />
         <activity
             android:name=".feature.notification.SchemeActivity"
-            android:exported="true"
+            android:exported="false"
             android:launchMode="singleTop"/>
         <activity
             android:name=".feature.main.MainActivity"

--- a/app/src/main/java/org/sopt/official/App.kt
+++ b/app/src/main/java/org/sopt/official/App.kt
@@ -36,6 +36,7 @@ import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import org.sopt.official.common.context.appContext
+import org.sopt.official.config.messaging.SoptNotificationChannel
 import org.sopt.official.localstorage.source.UserStorage
 import timber.log.Timber
 import javax.inject.Inject
@@ -50,6 +51,7 @@ class App : Application() {
     override fun onCreate() {
         super.onCreate()
         appContext = this.applicationContext
+        SoptNotificationChannel.create(this)
 
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
         lifecycleOwner.lifecycleScope.launch {

--- a/app/src/main/java/org/sopt/official/config/messaging/SoptFirebaseMessagingService.kt
+++ b/app/src/main/java/org/sopt/official/config/messaging/SoptFirebaseMessagingService.kt
@@ -24,10 +24,13 @@
  */
 package org.sopt.official.config.messaging
 
-import android.app.NotificationManager
+import android.Manifest
 import android.app.PendingIntent
+import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.google.firebase.messaging.RemoteMessage
 import com.skydoves.firebase.messaging.lifecycle.ktx.LifecycleAwareFirebaseMessagingService
@@ -106,16 +109,24 @@ class SoptFirebaseMessagingService : LifecycleAwareFirebaseMessagingService() {
         }
 
         val notifyId = System.currentTimeMillis().toInt()
-        val notificationBuilder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID).setContentTitle(title).setContentText(body)
+        val channelId = SoptNotificationChannel.id(this)
+        val notificationBuilder = NotificationCompat.Builder(this, channelId).setContentTitle(title).setContentText(body)
             .setStyle(NotificationCompat.BigTextStyle().bigText(body)).setSmallIcon(R.drawable.img_logo_small)
-            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC).setChannelId(getString(R.string.toolbar_notification)).setAutoCancel(true)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC).setAutoCancel(true)
 
         notificationBuilder.setNotificationContentIntent(
             notificationId, link, notifyId
         )
 
-        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.notify(notifyId, notificationBuilder.build())
+        if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) != PackageManager.PERMISSION_GRANTED
+        ) return
+
+        NotificationManagerCompat.from(this).notify(notifyId, notificationBuilder.build())
     }
 
     private fun NotificationCompat.Builder.setNotificationContentIntent(
@@ -132,16 +143,11 @@ class SoptFirebaseMessagingService : LifecycleAwareFirebaseMessagingService() {
 
         return this.setContentIntent(
             PendingIntent.getActivity(
-                this@SoptFirebaseMessagingService, notifyId, intent, if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
-                } else {
-                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                }
+                this@SoptFirebaseMessagingService,
+                notifyId,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
         )
-    }
-
-    companion object {
-        const val NOTIFICATION_CHANNEL_ID = "SOPT"
     }
 }

--- a/app/src/main/java/org/sopt/official/config/messaging/SoptNotificationChannel.kt
+++ b/app/src/main/java/org/sopt/official/config/messaging/SoptNotificationChannel.kt
@@ -1,0 +1,26 @@
+package org.sopt.official.config.messaging
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import org.sopt.official.R
+
+object SoptNotificationChannel {
+    fun id(context: Context): String = context.getString(R.string.default_channel_id)
+
+    fun create(context: Context) {
+        val channel = NotificationChannel(
+            id(context),
+            context.getString(R.string.toolbar_notification),
+            NotificationManager.IMPORTANCE_HIGH
+        ).apply {
+            setSound(null, null)
+            enableLights(false)
+            enableVibration(false)
+            lockscreenVisibility = NotificationCompat.VISIBILITY_PUBLIC
+        }
+        context.getSystemService(NotificationManager::class.java)
+            .createNotificationChannel(channel)
+    }
+}

--- a/app/src/main/java/org/sopt/official/feature/auth/AuthActivity.kt
+++ b/app/src/main/java/org/sopt/official/feature/auth/AuthActivity.kt
@@ -24,8 +24,6 @@
  */
 package org.sopt.official.feature.auth
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -42,7 +40,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.app.NotificationCompat
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -90,20 +87,6 @@ class AuthActivity : AppCompatActivity() {
 
                 LaunchedEffect(Unit) {
                     viewModel.getUpdateConfig(context.getVersionName())
-                }
-
-                LaunchedEffect(true) {
-                    NotificationChannel(
-                        getString(R.string.toolbar_notification),
-                        getString(R.string.toolbar_notification),
-                        NotificationManager.IMPORTANCE_HIGH
-                    ).apply {
-                        setSound(null, null)
-                        enableLights(false)
-                        enableVibration(false)
-                        lockscreenVisibility = NotificationCompat.VISIBILITY_PUBLIC
-                        (getSystemService(NOTIFICATION_SERVICE) as NotificationManager).createNotificationChannel(this)
-                    }
                 }
 
                 LaunchedEffect(viewModel.uiEvent, lifecycleOwner) {

--- a/app/src/main/java/org/sopt/official/feature/auth/AuthActivity.kt
+++ b/app/src/main/java/org/sopt/official/feature/auth/AuthActivity.kt
@@ -46,7 +46,6 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import org.sopt.official.R
 import org.sopt.official.common.util.getVersionName
 import org.sopt.official.common.util.launchPlayStore
 import org.sopt.official.config.FcmPushTokenManager
@@ -67,6 +66,7 @@ class AuthActivity : AppCompatActivity() {
 
     @Inject
     lateinit var userStorage: UserStorage
+
     @Inject
     lateinit var tokenStorage: TokenStorage
 
@@ -176,7 +176,7 @@ class AuthActivity : AppCompatActivity() {
         }
     }
 
-    private fun navigateToMainActivity(accessToken : String) {
+    private fun navigateToMainActivity(accessToken: String) {
         try {
             if (accessToken.isNotEmpty()) {
                 lifecycleScope.launch {

--- a/app/src/main/java/org/sopt/official/feature/notification/SchemeActivity.kt
+++ b/app/src/main/java/org/sopt/official/feature/notification/SchemeActivity.kt
@@ -49,6 +49,7 @@ import org.sopt.official.model.toViewType
 import timber.log.Timber
 import java.io.Serializable
 import javax.inject.Inject
+import androidx.core.net.toUri
 
 @AndroidEntryPoint
 class SchemeActivity : AppCompatActivity() {
@@ -142,10 +143,10 @@ class SchemeActivity : AppCompatActivity() {
                     DeepLinkType.EXPIRED
                 )
 
-                else -> when (link.contains("http://") || link.contains("https://")) {
+                else -> when (link.startsWith("http://") || link.startsWith("https://")) {
                     true -> Intent(
                         Intent.ACTION_VIEW,
-                        Uri.parse(link)
+                        link.toUri()
                     )
 
                     false -> DeepLinkType.of(link).getIntent(

--- a/app/src/main/java/org/sopt/official/feature/notification/SchemeActivity.kt
+++ b/app/src/main/java/org/sopt/official/feature/notification/SchemeActivity.kt
@@ -27,9 +27,9 @@ package org.sopt.official.feature.notification
 import android.app.TaskStackBuilder
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.EntryPointAccessors
@@ -49,7 +49,6 @@ import org.sopt.official.model.toViewType
 import timber.log.Timber
 import java.io.Serializable
 import javax.inject.Inject
-import androidx.core.net.toUri
 
 @AndroidEntryPoint
 class SchemeActivity : AppCompatActivity() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,8 @@
 -->
 <resources>
     <string name="app_name">SOPT</string>
-    <string name="default_channel_id">SOPT_MESSAGE</string>
+    <!-- Keep the legacy channel ID so existing users retain their channel settings. -->
+    <string name="default_channel_id" translatable="false">알림</string>
     <string name="main_content_header">SOPT를 알차게 즐기고 싶다면?</string>
     <string name="soptamp">SOPT-AMP!</string>
     <string name="poke">콕 찌르기</string>

--- a/core/localstorage/src/main/java/org/sopt/official/localstorage/source/UserStorage.kt
+++ b/core/localstorage/src/main/java/org/sopt/official/localstorage/source/UserStorage.kt
@@ -33,9 +33,11 @@ import org.sopt.official.model.UserStatus
  * @param pushToken 푸시 토큰
  * @param platform 인증 플랫폼
  * @param isSopletterOnboardingCompleted 솝레터 온보딩 완료 여부
+ * @param isNotificationPermissionRequested 알림 권한 요청 여부
  * @param saveUserStatus 유저 상태 저장
  * @param savePushToken 푸시 토큰 저장
  * @param savePlatform 인증 플랫폼 저장
+ * @param saveNotificationPermissionRequested 알림 권한 요청 여부 저장
  * @param clearUser 유저 정보 초기화
  * */
 interface UserStorage {
@@ -44,11 +46,13 @@ interface UserStorage {
     val platform: Flow<String>
     val isSopletterOnboardingCompleted: Flow<Boolean?>
     val isAppjamMode: Flow<Boolean>
+    val isNotificationPermissionRequested: Flow<Boolean>
 
     suspend fun saveUserStatus(status: UserStatus)
     suspend fun savePushToken(token: String)
     suspend fun savePlatform(platform: String)
     suspend fun saveOnboardingCompleted(isOnboarded: Boolean)
     suspend fun saveIsAppjamMode(isAppjamMode: Boolean)
+    suspend fun saveNotificationPermissionRequested(isRequested: Boolean)
     suspend fun clearUser()
 }

--- a/core/localstorage/src/main/java/org/sopt/official/localstorage/sourceimpl/DefaultSoptStorage.kt
+++ b/core/localstorage/src/main/java/org/sopt/official/localstorage/sourceimpl/DefaultSoptStorage.kt
@@ -67,6 +67,10 @@ class DefaultSoptStorage @Inject constructor(
         preferences[KEY_IS_APPJAM_MODE] ?: false
     }
 
+    override val isNotificationPermissionRequested: Flow<Boolean> = dataStore.data.map { preferences ->
+        preferences[KEY_NOTIFICATION_PERMISSION_REQUESTED] ?: false
+    }
+
     override suspend fun saveTokens(accessToken: String, refreshToken: String) {
         dataStore.edit { preferences ->
             preferences[KEY_ACCESS_TOKEN] = accessToken.encryptInReleaseMode(keyAlias = ACCESS_TOKEN_KEY_ALIAS)
@@ -131,6 +135,12 @@ class DefaultSoptStorage @Inject constructor(
         }
     }
 
+    override suspend fun saveNotificationPermissionRequested(isRequested: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[KEY_NOTIFICATION_PERMISSION_REQUESTED] = isRequested
+        }
+    }
+
     override suspend fun clearUser() {
         dataStore.edit { preferences ->
             preferences.remove(KEY_USER_STATUS)
@@ -141,7 +151,11 @@ class DefaultSoptStorage @Inject constructor(
 
     override suspend fun clearAll() {
         dataStore.edit { preferences ->
+            val isNotificationPermissionRequested = preferences[KEY_NOTIFICATION_PERMISSION_REQUESTED]
             preferences.clear()
+            isNotificationPermissionRequested?.let {
+                preferences[KEY_NOTIFICATION_PERMISSION_REQUESTED] = it
+            }
         }
     }
 
@@ -154,6 +168,7 @@ class DefaultSoptStorage @Inject constructor(
         private val KEY_PLATFORM = stringPreferencesKey("platform")
         private val KEY_ONBOARDING_COMPLETED = booleanPreferencesKey("onboarding_completed")
         private val KEY_IS_APPJAM_MODE = booleanPreferencesKey("is_appjam_mode")
+        private val KEY_NOTIFICATION_PERMISSION_REQUESTED = booleanPreferencesKey("notification_permission_requested")
 
 
         private const val DEFAULT_VALUE = ""

--- a/feature/main/src/main/java/org/sopt/official/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/org/sopt/official/feature/main/MainActivity.kt
@@ -24,26 +24,35 @@
  */
 package org.sopt.official.feature.main
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import org.sopt.official.analytics.Tracker
 import org.sopt.official.analytics.compose.ProvideTracker
 import org.sopt.official.common.context.appContext
-import org.sopt.official.model.UserStatus
 import org.sopt.official.common.navigator.DeepLinkType
 import org.sopt.official.common.navigator.NavigatorEntryPoint
 import org.sopt.official.designsystem.SoptTheme
+import org.sopt.official.localstorage.source.UserStorage
+import org.sopt.official.model.UserStatus
 import java.io.Serializable
 import javax.inject.Inject
 
@@ -61,12 +70,19 @@ class MainActivity : AppCompatActivity() {
     @Inject
     lateinit var tracker: Tracker
 
+    @Inject
+    lateinit var userStorage: UserStorage
+
     private var intentState by mutableStateOf<Intent?>(null)
+    private val notificationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) {}
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         intentState = intent
         val startArgs = intent.getSerializableExtra(ARGS) as? StartArgs
+        val userStatus = startArgs?.userStatus ?: UserStatus.UNAUTHENTICATED
 
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.dark(
@@ -77,13 +93,14 @@ class MainActivity : AppCompatActivity() {
             SoptTheme {
                 ProvideTracker(tracker) {
                     MainScreen(
-                        userStatus = startArgs?.userStatus ?: UserStatus.UNAUTHENTICATED,
+                        userStatus = userStatus,
                         intentState = intentState,
                         applicationNavigator = applicationNavigator
                     )
                 }
             }
         }
+        requestNotificationPermissionOnce(userStatus)
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -91,6 +108,28 @@ class MainActivity : AppCompatActivity() {
         setIntent(intent)
 
         intentState = intent
+    }
+
+    private fun requestNotificationPermissionOnce(userStatus: UserStatus) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        if (userStatus == UserStatus.UNAUTHENTICATED) return
+
+        lifecycleScope.launch {
+            if (
+                ContextCompat.checkSelfPermission(
+                    this@MainActivity,
+                    Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED
+            ) {
+                userStorage.saveNotificationPermissionRequested(true)
+                return@launch
+            }
+
+            if (userStorage.isNotificationPermissionRequested.first()) return@launch
+
+            userStorage.saveNotificationPermissionRequested(true)
+            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
     }
 
     data class StartArgs(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 compileSdk = "36"
 minSdk = "30"
-targetSdk = "35"
+targetSdk = "36"
 appVersion = "4.9.0"
 versionCode = "40900"
 


### PR DESCRIPTION
## Related issue 🛠
- closed #1649

## Work Description ✏️
기존에 빠져있던 알림 권한 요청 로직을 추가했습니다. 변경사항은 아래와 같아요.

- Android 13 이상 회원의 최초 홈 진입 시 알림 권한 요청(비회원은 권한 요청에서 제외)
- 요청 여부를 DataStore에 저장하여 한 번만 노출
- `PendingIntent`를 `FLAG_IMMUTABLE`로 변경

## Screenshot 📸
<img width="360"  alt="image" src="https://github.com/user-attachments/assets/4bf35cec-f38a-49b7-8cab-f94b676f5018" />


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
앱 내 알림권한 요청을 받는 부분이 없어 시스템 권한 팝업을 노출하는 방식을 적용해놓았는데, 추후에 바텀시트 등의 안내 UI 와 함께 커스텀 권한 요청을 적용하는 것도 고려해 보면 좋을거 같습니다.

++ targetSdk 36 으로 올리고 전체적인 서비스 동작 여부 확인했습니다.